### PR TITLE
Decide what to do with return None in invoke()

### DIFF
--- a/pydash/collections.py
+++ b/pydash/collections.py
@@ -195,14 +195,9 @@ def invoke(collection, method_name, *args):
 
     for item in collection:
         if callable(method_name):
-            result = method_name(item, *args)
+            lst.append(method_name(item, *args))
         else:
-            result = getattr(item, method_name)(*args)
-
-        if result is None:
-            lst.append(item)
-        else:
-            lst.append(result)
+            lst.append(getattr(item, method_name)(*args))
 
     return lst
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -216,7 +216,9 @@ def test_index_by(case, expected):
 
 
 @parametrize('case,expected', [
-    (([[5, 1, 7], [3, 2, 1]], 'sort'), [[1, 5, 7], [1, 2, 3]]),
+    (([[5, 1, 7], [3, 2, 1]], 'sort'), [None, None]),
+    (([[5, 1, 7], [3, 2, 1]], lambda lst: sorted(lst)),
+     [[1, 5, 7], [1, 2, 3]]),
     (([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}], 'get', 'a'), [1, 3]),
     (([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}], 'get', 'c'), [None, None]),
     ((['anaconda', 'bison', 'cat'], 'count', 'a'), [3, 0, 1]),


### PR DESCRIPTION
Adding the collection item when no value is returned (in the case of `sort()`) is consistent with Lo-Dash, but adding the collection item when `None` is explicitly returned is obviously wrong.

1st and 3rd tests break either way.
