### PR TITLE
When pydash.objects.get uses a default value, stop processing keys in

### DIFF
--- a/pydash/objects.py
+++ b/pydash/objects.py
@@ -18,7 +18,8 @@ from .helpers import (
     set_item,
     NoValue,
     callit,
-    getargcount
+    getargcount,
+    UsingDefault
 )
 from ._compat import iteritems, text_type
 from .utilities import to_path
@@ -496,10 +497,14 @@ def get(obj, path, default=None):
         - Added :func:`get` as main definition and :func:`get_path` as alias.
         - Made :func:`deep_get` an alias.
     """
-    for key in to_path(path):
-        obj = get_item(obj, key, default=default)
-        if obj is None:
-            break
+    try:
+        for key in to_path(path):
+            obj = get_item(obj, key, default=default,
+                           raise_if_default_used=True)
+            if obj is None:
+                break
+    except UsingDefault as ud:
+        return ud.default_value
 
     return obj
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -225,6 +225,7 @@ def test_for_in_right_aliases(case):
     (({'one': {'two': {'three': 4}}}, ['one', 'two', 'three']), 4),
     (({'one': {'two': {'three': 4}}}, 'one.four'), None),
     (({'one': {'two': {'three': 4}}}, 'one.four.three', []), []),
+    (({'one': {'two': {'three': 4}}}, 'one.four.0.a', [{'a': 1}]), [{'a': 1}]),
     (({'one': {'two': {'three': [{'a': 1}]}}}, 'one.four.three.0.a', []), []),
     (({'one': {'two': {'three': 4}}}, 'one.four.three'), None),
     (({'one': {'two': {'three': [{'a': 1}]}}}, 'one.four.three.0.a'), None),
@@ -252,6 +253,8 @@ def test_for_in_right_aliases(case):
     (({'lev.el1': {'lev\\el2': {'level3': ['value']}}},
       'lev\\.el1.lev\\\\el2.level3.[0]'),
      'value'),
+    (({'one': ['hello', 'there']}, 'one.bad.hello', []), []),
+    (({'one': ['hello', None]}, 'one.1.hello'), None)
 ])
 def test_get(case, expected):
     assert _.get(*case) == expected


### PR DESCRIPTION
the path and just return the default value.

Solves #78 .