### PR TITLE
getargspec -> getfullargspec in python 3

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors
 - Klaus Sevensleeper, k7sleeper@gmail.com, `k7sleeper@github <https://github.com/k7sleeper>`_
 - Bharadwaj Yarlagadda, yarlagaddabharadwaj@gmail.com, `bharadwajyarlagadda@github <https://github.com/bharadwajyarlagadda>`_
 - Michael James, `urbnjamesmi1 <https://github.com/urbnjamesmi1>`_
+- Tim Griesser, tgriesser@gmail.com, `tgriesser@github <https://github.com/tgriesser>`_

--- a/pydash/_compat.py
+++ b/pydash/_compat.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import sys
 import cgi
+import inspect
 from collections import Hashable
 from decimal import Decimal
 from functools import partial
@@ -38,6 +39,7 @@ if PY3:
     integer_types = (int,)
     number_types = (int, float, Decimal)
     builtins = _builtins.__dict__.values()
+    getfullargspec = inspect.getfullargspec
 
     def iterkeys(d): return iter(d.keys())
 
@@ -62,6 +64,7 @@ else:
     string_types = (str, unicode)
     integer_types = (int, long)
     number_types = (int, long, float, Decimal)
+    getfullargspec = inspect.getargspec
 
     def iterkeys(d): return d.iterkeys()
 

--- a/pydash/functions.py
+++ b/pydash/functions.py
@@ -6,11 +6,10 @@
 
 from __future__ import absolute_import
 
-import inspect
 import time
 
 import pydash as pyd
-from ._compat import _range
+from ._compat import _range, getfullargspec
 
 
 __all__ = (
@@ -134,7 +133,7 @@ class Curry(object):
     """Wrap a function in a curry context."""
     def __init__(self, func, arity, args=None, kargs=None):
         self.func = func
-        self.arity = (len(inspect.getargspec(func).args) if arity is None
+        self.arity = (len(getfullargspec(func).args) if arity is None
                       else arity)
         self.args = () if args is None else args
         self.kargs = {} if kargs is None else kargs

--- a/pydash/helpers.py
+++ b/pydash/helpers.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 from collections import Iterable
 from functools import wraps
 import inspect
-import re
 import warnings
 
 import pydash as pyd

--- a/pydash/helpers.py
+++ b/pydash/helpers.py
@@ -6,11 +6,11 @@ from __future__ import absolute_import
 
 from collections import Iterable
 from functools import wraps
-import inspect
+
 import warnings
 
 import pydash as pyd
-from ._compat import iteritems
+from ._compat import iteritems, getfullargspec
 
 
 class _NoValue(object):
@@ -51,7 +51,7 @@ def getargcount(callback, maxargs):
         argcount = 1
     else:
         try:
-            argspec = inspect.getargspec(callback)
+            argspec = getfullargspec(callback)
 
             if argspec and not argspec.varargs:
                 # Use inspected arg count.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from copy import deepcopy
-
 import pytest
 
 from pydash._compat import iteritems

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
 from pydash._compat import iteritems
-
 
 # pytest.mark is a generator so create alias for convenience
 parametrize = pytest.mark.parametrize

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+import pydash as _
+from pydash._compat import PY3
+
+
+if PY3:
+    # Hack around the fact that we can't define this kind of function in
+    # Python 2 so have to rely on conditionally creating it using exec()
+    # to avoid syntax errors while still having this test case covered for
+    # Python 3.
+    exec('def typed_function(row: int, index: int, col: list): return row + 1')
+else:
+    typed_function = None
+
+
+@pytest.mark.skipif(not PY3, reason='test requires Python 3 annotations')
+def test_annotated_callback():
+    assert _.map_([1, 2], typed_function) == [2, 3]

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import math
-import warnings
 
 import pydash as _
 from .fixtures import parametrize

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -6,7 +6,6 @@ import pydash as _
 
 import pytest
 
-from . import fixtures
 from .fixtures import parametrize
 
 


### PR DESCRIPTION
Currently seeing a `ValueError` if a callback specifies type annotations