### PR TITLE
Fixed rendering of docstring

### DIFF
--- a/pydash/objects.py
+++ b/pydash/objects.py
@@ -1190,8 +1190,7 @@ def transform(obj, callback=None, accumulator=None):
 
     Example:
 
-        >>> transform([1, 2, 3, 4],\
-                      lambda acc, value, key: acc.append((key, value)))
+        >>> transform([1, 2, 3, 4], lambda acc, v, k: acc.append((k, v)))
         [(0, 1), (1, 2), (2, 3), (3, 4)]
 
     .. versionadded:: 1.0.0


### PR DESCRIPTION
For the sake of the readability of the documentation, shall we overlook the 80-column limit for this docstring?