### PR TITLE
Use standard replace instead of regex

### DIFF
--- a/pydash/utilities.py
+++ b/pydash/utilities.py
@@ -1045,8 +1045,8 @@ def to_path_tokens(value):
 
 def unescape_path_key(key):
     """Unescape path key."""
-    key = pyd.reg_exp_js_replace(key, r'/\\\\/g', r'\\')
-    key = pyd.reg_exp_js_replace(key, r'/\\\./g', '.')
+    key = key.replace(r'\\', '\\')
+    key = key.replace(r'\.', r'.')
     return key
 
 


### PR DESCRIPTION
pydash.get can be quite slow.  

`unescaped_path_key` was using `reg_exp_js_replace` to replace `\\` and `\.` in keys.  This seems like overkill.  Instead, use standard string replace. 

In my tests this seems to speed up `_.get` by a factor of 8-10x