### PR TITLE
Omit nested path

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Contributors
 - Michael James, `urbnjamesmi1@github <https://github.com/urbnjamesmi1>`_
 - Tim Griesser, tgriesser@gmail.com, `tgriesser@github <https://github.com/tgriesser>`_
 - Shaun Patterson, `shaunpatterson@github <https://github.com/shaunpatterson>`_
+- Brian Beck, `beck3905@github <https://github.com/beck3905>`_

--- a/pydash/__init__.py
+++ b/pydash/__init__.py
@@ -124,6 +124,7 @@ from .collections import (
     for_each,
     for_each_right,
     group_by,
+    group_lists,
     includes,
     invoke_map,
     key_by,

--- a/pydash/collections.py
+++ b/pydash/collections.py
@@ -28,6 +28,7 @@ __all__ = (
     'for_each',
     'for_each_right',
     'group_by',
+    'group_lists',
     'includes',
     'invoke_map',
     'key_by',
@@ -401,6 +402,44 @@ def group_by(collection, iteratee=None):
         key = cbk(value)
         ret.setdefault(key, [])
         ret[key].append(value)
+
+    return ret
+
+
+def group_lists(collection):
+    """Creates an object composed of keys generated from the merging of
+    multiple lists with similar values in the same index.
+
+        Args:
+            collection (list): List of lists to iterate over.
+
+        Returns:
+            dict: Results of grouping lists.
+
+        Example:
+
+            >>> results = group_lists([ \
+                    ['a', 'b'], \
+                    ['a', 'b', 'c'], \
+                    ['a', 'c'], \
+                    ['a', 'c', 'd'] \
+                ])
+            >>> assert results == {'a': {'b': {'c': {}}, 'c': {'d': {}}}}
+
+        """
+    ret = {}
+
+    def recursive_group(obj, paths):
+        if len(paths):
+            key = paths.pop(0)
+            if key in obj:
+                obj[key].update(recursive_group({}, paths))
+            else:
+                obj[key] = recursive_group({}, paths)
+        return obj
+
+    for item in collection:
+        pyd.merge(ret, recursive_group({}, item))
 
     return ret
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -158,6 +158,18 @@ def test_group_by(case, expected):
 
 
 @parametrize('case,expected', [
+    (([
+        ['a', 'b'],
+        ['a', 'b', 'c'],
+        ['a', 'c'],
+        ['a', 'c', 'd']
+    ],), {'a': {'b': {'c': {}}, 'c': {'d': {}}}})
+])
+def test_group_lists(case, expected):
+    assert _.group_lists(*case) == expected
+
+
+@parametrize('case,expected', [
     (([1, 2, 3], 1), True),
     (([1, 2, 3], 1, 2), False),
     (({'name': 'fred', 'age': 40}, 'fred'), True),

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -406,7 +406,9 @@ def test_merge_with(case, expected):
     (({'a': 1, 'b': 2, 'c': 3}, ['a'], ['b']), {'c': 3}),
     (([1, 2, 3],), {0: 1, 1: 2, 2: 3}),
     (([1, 2, 3], 0), {1: 2, 2: 3}),
-    (([1, 2, 3], 0, 1), {2: 3})
+    (([1, 2, 3], 0, 1), {2: 3}),
+    (({'a': {'b': {'c': 'd'}}, 'e': 'f'}, 'a.b.c', 'e'),
+     {'a': {'b': {}}})
 ])
 def test_omit(case, expected):
     assert _.omit(*case) == expected
@@ -417,7 +419,7 @@ def test_omit(case, expected):
     (({'a': 1, 'b': 2, 'c': 3}, lambda value, key: key == 'a'),
      {'b': 2, 'c': 3}),
     (([1, 2, 3],), {0: 1, 1: 2, 2: 3}),
-    (([1, 2, 3], [0]), {1: 2, 2: 3}),
+    (([1, 2, 3], [0]), {1: 2, 2: 3})
 ])
 def test_omit_by(case, expected):
     assert _.omit_by(*case) == expected


### PR DESCRIPTION
Added the ability to use a nested path in the omit command.  All existing tests pass without changes and added a new parameter for the new use case.  Also added the ability to group lists based on the value in each index.