### PR TITLE
simplify usage of potentially single values

### DIFF
--- a/pydash/__init__.py
+++ b/pydash/__init__.py
@@ -46,6 +46,7 @@ from .arrays import (
     intersperse,
     last,
     last_index_of,
+    listify,
     mapcat,
     nth,
     pop,

--- a/pydash/arrays.py
+++ b/pydash/arrays.py
@@ -44,6 +44,7 @@ __all__ = (
     'intersperse',
     'last',
     'last_index_of',
+    'listify',
     'mapcat',
     'nth',
     'pull',
@@ -890,6 +891,41 @@ def last_index_of(array, value, from_index=None):
             return index
         index -= 1
     return -1
+
+
+def listify(item):
+    """Ensure the item is an iterable by wrapping single values in a list.
+
+    Args:
+        item (mixed): Item to wrap in a list.
+
+    Returns:
+        list: Wrapped item.
+
+    Example:
+
+        >>> listify(1)
+        [1]
+
+        >>> listify([1])
+        [1]
+
+        >>> listify({1: 2, 3: 4})
+        [1, 3]
+
+        >>> listify(a for a in [1, 2, 3])
+        [1, 2, 3]
+
+    .. versionadded:: 4.3
+    """
+    if isinstance(item, list):
+        return item
+
+    elif hasattr(item, '__iter__'):
+        return list(item)
+
+    else:
+        return [item]
 
 
 def mapcat(array, iteratee=None):

--- a/pydash/arrays.py
+++ b/pydash/arrays.py
@@ -716,6 +716,9 @@ def intersection(array, *others):
         >>> intersection([1, 2, 3], [1, 2, 3, 4, 5], [2, 3])
         [2, 3]
 
+        >>> intersection([1, 2, 3])
+        [1, 2, 3]
+
     .. versionadded:: 1.0.0
 
     .. versionchanged:: 4.0.0


### PR DESCRIPTION
I often have the problem that i don't know if a value given by a user is a list or a single value. My API allows to give for example a list of database ids to work on or just a single id. For this reason i have to check if the given value is already a list / tuple and if not, transform it before i can apply further pydash functions.

For this reason it would be nice to have a pydash function that wraps single values in a list. Especially for chaining.

My issue:
```
>>> py_(1).sum().value()
0
```

Simplification using listify:
```
>>> listify(1)
[1]
```

```
>>> listify([1])
[1]
```

```
>>> listify({1: 2, 3: 4})
[1, 3]
```

```
>>> listify(a for a in [1, 2, 3])
[1, 2, 3]
```

Chained:
```
>>> py_(1).listify().sum().value()
1
```

```
>>> py_([1, 2, 3]).listify().sum().value()
6
```

