### PR TITLE
allow to use to_list as decorator

### DIFF
--- a/pydash/objects.py
+++ b/pydash/objects.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 import copy
 from functools import partial
+from functools import wraps
 import math
 import re
 
@@ -1393,16 +1394,29 @@ def to_list(obj, split_strings=True):
         - Convert other iterables to list.
         - Byte objects are returned as single character strings in Python 3.
     """
+
     if isinstance(obj, list):
         return obj[:]
+
     elif isinstance(obj, dict):
         return obj.values()
+
     elif not split_strings and (isinstance(obj, string_types) or
                                 isinstance(obj, bytes)):
         return [obj]
+
     elif split_strings and isinstance(obj, bytes):
         # in python3 iterating over bytes gives integers instead of strings
         return list(chr(c) if isinstance(c, int) else c for c in obj)
+
+    elif callable(obj):
+
+        @wraps(obj)
+        def decorator(*arg, **kwargs):
+            return to_list(obj(*arg, **kwargs))
+
+        return decorator
+
     else:
         try:
             return list(obj)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -648,3 +648,14 @@ def test_sort_by(case, expected):
 ])
 def test_to_list(case, expected):
     assert set(_.to_list(*case)) == set(expected)
+
+
+def test_to_list_decorator():
+
+    @_.to_list
+    def foo():
+        yield "b"
+        yield "a"
+        yield "r"
+
+    assert foo() == ['b', 'a', 'r']

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -219,6 +219,15 @@ def test_memoize(case, args, kargs, key):
     assert memoized.cache[key] == expected
 
 
+def test_memoize_decorator():
+
+    @_.memoize
+    def foo():
+        return object()
+
+    assert foo() == foo()
+
+
 @parametrize('case,args,kargs,expected', [
     (('a.b',), ({'a': {'b': lambda x, y: x + y}}, 1, 2), {}, 3),
     (('a.b',), ({'a': {'b': lambda x, y: x + y}}, 1,), {'y': 2}, 3),


### PR DESCRIPTION
I often write functions that collect data as list and then somehow return them. For this reason it's mostly required to create an internal variable to collect the data and return that at the end. To safe these repeating lines, I modified the to_list function to also act as decorator, so i can use ``yield`` to create lists.

    >>> @py_.to_list
    >>> def foo():
    >>>     yield "b"
    >>>     yield "a"
    >>>     yield "r"
    >>>     if "something" is True:
    >>>         yield "s"
    >>>
    >>> foo()
    ['b', 'a', 'r']

Actually i'm not sure if you want functionality like this in pydash. But let's give it a try 🙃. I also added a test to the memoize function, where i use the same technique to call it. 