### PR TITLE
Change quickstart imports/usage to be more consistent

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,10 +9,9 @@ The first is by using the module directly or importing from it:
 .. doctest::
 
     >>> import pydash
-    >>> from pydash import flatten
 
     # Arrays
-    >>> flatten([1, 2, [3, [4, 5, [6, 7]]]])
+    >>> pydash.flatten([1, 2, [3, [4, 5, [6, 7]]]])
     [1, 2, 3, [4, 5, [6, 7]]]
 
     >>> pydash.flatten_deep([1, 2, [3, [4, 5, [6, 7]]]])


### PR DESCRIPTION
Just a minor thing I noticed about the Quickstart guide - `flatten` is imported into the namespace whereas all the other functions are used against the `pydash` namespace. This PR changes them all to be consistent on this page.