### PR TITLE
Fixed bug where getattr is used on Mappings and Sequence in Python 3.5+

### DIFF
--- a/src/pydash/_compat.py
+++ b/src/pydash/_compat.py
@@ -27,7 +27,7 @@ def _identity(x): return x
 
 
 if PY2:
-    from collections import Hashable, Iterable
+    from collections import Hashable, Iterable, Sequence, Mapping
     from HTMLParser import HTMLParser
     from itertools import izip
     from urllib import urlencode
@@ -56,7 +56,7 @@ if PY2:
         cls.__str__ = lambda x: x.__unicode__().encode('utf-8')
         return cls
 else:
-    from collections.abc import Hashable, Iterable
+    from collections.abc import Hashable, Iterable, Sequence, Mapping
     import html
     from html.parser import HTMLParser
     from urllib.parse import (

--- a/src/pydash/helpers.py
+++ b/src/pydash/helpers.py
@@ -11,15 +11,23 @@ import warnings
 import pydash as pyd
 from ._compat import Iterable, PY2, iteritems, getfullargspec, string_types
 
+_attr_ignored_types = (dict, list)
+if not PY2:
+    try:
+        from typing import Sequence, Mapping
+        _attr_ignored_types = (dict, list, Sequence, Mapping)
+    except Exception:
+        pass
+
 
 class _NoValue(object):
-    """Represents an unset value. Used to differeniate between an explicit
+    """Represents an unset value. Used to differentiate between an explicit
     ``None`` and an unset value.
     """
     pass
 
 
-#: Singleton object that differeniates between an explicit ``None`` value and
+#: Singleton object that differentiates between an explicit ``None`` value and
 #: an unset value.
 NoValue = _NoValue()
 
@@ -142,9 +150,9 @@ def base_get(obj, key, default=NoValue):
     except Exception:
         pass
 
-    if not isinstance(obj, (dict, list)):
+    if not isinstance(obj, _attr_ignored_types) or hasattr(obj, '_fields'):
         # Don't add attrgetter for dict/list objects since we don't want class
-        # methods/attributes returned for them.
+        # methods/attributes returned for them. Always allow getattr for namedtuple
         try:
             # Only add attribute getter if key is string.
             getters.append(attrgetter(key))

--- a/src/pydash/helpers.py
+++ b/src/pydash/helpers.py
@@ -9,15 +9,9 @@ from operator import attrgetter, itemgetter
 import warnings
 
 import pydash as pyd
-from ._compat import Iterable, PY2, iteritems, getfullargspec, string_types
+from ._compat import Iterable, PY2, iteritems, getfullargspec, string_types, Sequence, Mapping
 
-_attr_ignored_types = (dict, list)
-if not PY2:
-    try:
-        from typing import Sequence, Mapping
-        _attr_ignored_types = (dict, list, Sequence, Mapping)
-    except Exception:
-        pass
+_attr_ignored_types = (Mapping, Sequence)
 
 
 class _NoValue(object):
@@ -150,7 +144,7 @@ def base_get(obj, key, default=NoValue):
     except Exception:
         pass
 
-    if not isinstance(obj, _attr_ignored_types) or hasattr(obj, '_fields'):
+    if not isinstance(obj, _attr_ignored_types) or (isinstance(obj, tuple) and hasattr(obj, "_fields")):
         # Don't add attrgetter for dict/list objects since we don't want class
         # methods/attributes returned for them.
         # Always allow getattr for namedtuple.

--- a/src/pydash/helpers.py
+++ b/src/pydash/helpers.py
@@ -152,7 +152,8 @@ def base_get(obj, key, default=NoValue):
 
     if not isinstance(obj, _attr_ignored_types) or hasattr(obj, '_fields'):
         # Don't add attrgetter for dict/list objects since we don't want class
-        # methods/attributes returned for them. Always allow getattr for namedtuple
+        # methods/attributes returned for them.
+        # Always allow getattr for namedtuple.
         try:
             # Only add attribute getter if key is string.
             getters.append(attrgetter(key))

--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -479,7 +479,7 @@ def get(obj, path, default=None):
     described by `path`. If path doesn't exist, `default` is returned.
 
     Args:
-        obj (list|dict): Object to process.
+        obj (list|dict|typing.Sequence|typing.Mapping): Object to process.
         path (str|list): List or ``.`` delimited string of path describing
             path.
 
@@ -523,6 +523,9 @@ def get(obj, path, default=None):
 
         - Support attribute access on `obj` if item access fails.
         - Removed aliases ``get_path`` and ``deep_get``.
+
+    .. versionchanged:: 4.7.6
+        Fixed bug where getattr is used on Mappings and Sequence in Python 3.5+
     """
     if default is NoValue:
         # When NoValue given for default, then this method will raise if path


### PR DESCRIPTION
I found a case where objects in Python 3.5+ which use generic collections (Sequence, Mapping, not sure about others) were having `getattr` applied to them, creating an issue where `get(mymapping, 'values')` would return the mapping values instead of the key 'values'.

This PR resolves the issue mentioned above. Versions of python < 3.5 should not be affected. I was able to run tests successfully, but I am missing several interpreter versions on my machine so I ask that you re-test if there isn't a CI setup. I did not add a unit test case to confirm this behavior because I'm not sure how to have python version specific tests for tox.

P.S. I noticed that requirements.txt and requirements-dev.txt appear to have been removed/clobbered at some point in the past, but are still mentioned in `contributing.rst`.