### PR TITLE
Support leaf_predicate

### DIFF
--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -333,7 +333,7 @@ def test_map_values(case, expected):
                 'value': 'value 3'
             }
         }}},
-      lambda value, property_path: '.'.join(property_path) + '==' + value),
+      lambda value, property_path: '.'.join(property_path) + '==' + value, lambda v: isinstance(v, str)),
      {'level1': {
          'value': 'level1.value==value 1',
          'level2': {
@@ -345,7 +345,7 @@ def test_map_values(case, expected):
     (([['value 1', [['value 2', ['value 3']]]]],
       lambda value, property_path: (_.join(property_path, '.') +
                                     '==' +
-                                    value)),
+                                    value), lambda v: isinstance(v, str)),
      [['0.0==value 1', [['0.1.0.0==value 2', ['0.1.0.1.0==value 3']]]]]),
 ])
 def test_map_values_deep(case, expected):


### PR DESCRIPTION
```
>>> x = {'a': [], 'b': {'c': []}}
>>> z = map_values_deep(x, lambda val: val.append(1), lambda leaf: isinstance(leaf, list))
>>> z == {'a': [1], 'b': {'c': [1]}}
```

Could you support something like this? I tried to implement it, but it doesn't work well for some reason.
Please just check it and let me know how to fix it if this feature is acceptable.

Thanks.