### PR TITLE
Fixes issue #136

### DIFF
--- a/src/pydash/_compat.py
+++ b/src/pydash/_compat.py
@@ -84,13 +84,13 @@ else:
     izip = zip
 
     def _cmp(a, b):
-            if (a is None and b is None):
-                return 0
-            elif (a is None):
-                return -1
-            elif(b is None):
-                return 1
-            return (a > b) - (a < b)
+        if (a is None and b is None):
+            return 0
+        elif (a is None):
+            return -1
+        elif(b is None):
+            return 1
+        return (a > b) - (a < b)
 
 
 builtins = dict((value, key) for key, value in iteritems(_builtins.__dict__)

--- a/src/pydash/_compat.py
+++ b/src/pydash/_compat.py
@@ -83,7 +83,14 @@ else:
     implements_to_string = _identity
     izip = zip
 
-    def _cmp(a, b): return (a > b) - (a < b)
+    def _cmp(a, b):
+            if (a is None and b is None):
+                return 0
+            elif (a is None):
+                return -1
+            elif(b is None):
+                return 1
+            return (a > b) - (a < b)
 
 
 builtins = dict((value, key) for key, value in iteritems(_builtins.__dict__)


### PR DESCRIPTION
Fixes issue #136
Changed function **_cmp** to accept NoneType arguments. If one of the arguments is None it considers it as the smaller one. If both are None then the function returns 0, as if they were equal. Passed all tests in Tox.
