### PR TITLE
Fix/consider property annotation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,5 @@ Contributors
 - Brian Beck, `beck3905@github <https://github.com/beck3905>`_
 - Frank Epperlein, `efenka@github <https://github.com/efenka>`_
 - Joshua Wilson, `jwilson8767@github <https://github.com/jwilson8767>`_
+- Hugo Mendes, `hugosoftdev@github <https://github.com/hugosoftdev>`_
+- Isabella Oliveira, `isabellaro@github <https://github.com/IsabellaRO>`_

--- a/src/pydash/helpers.py
+++ b/src/pydash/helpers.py
@@ -111,7 +111,7 @@ def iterator(obj):
     elif isinstance(obj, Iterable):
         return enumerate(obj)
     else:
-        return iteritems(getattr(obj, '__dict__', {}))
+        return iteritems(dict((attribute, getattr(obj, attribute)) for attribute in dir(obj) if not attribute.startswith('__')))
 
 
 def base_get(obj, key, default=NoValue):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,6 +14,14 @@ class Object(object):
         for key, value in iteritems(attrs):
             setattr(self, key, value)
 
+class ObjectWithDecoratorProperty():
+    @property
+    def testProperty(self):
+        return 5
+
+    def __init__(self, **attrs):
+        for key, value in iteritems(attrs):
+            setattr(self, key, value)
 
 class ItemsObject(object):
     def __init__(self, items):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -471,6 +471,7 @@ def test_parse_int(case, expected):
     (([1, 2, 3],), {}),
     (([1, 2, 3], 0), {0: 1}),
     ((fixtures.Object(a=1, b=2, c=3), 'a'), {'a': 1}),
+    ((fixtures.ObjectWithDecoratorProperty(a=1), ['testProperty','a']), {'testProperty': 5, 'a':1}),
     ((fixtures.ItemsObject({'a': 1, 'b': 2, 'c': 3}), 'a'), {'a': 1}),
     ((fixtures.IteritemsObject({'a': 1, 'b': 2, 'c': 3}), 'a'), {'a': 1}),
     (({'a': {'b': 1, 'c': 2, 'd': 3}}, 'a.b', 'a.d'), {'a': {'b': 1, 'd': 3}}),


### PR DESCRIPTION
This modification is useful to enable that objects derivated from classes with a property declared as a method+decorator also can be "picked" by the .pick() function.

Fixing the issue #108 .