### PR TITLE
Fixes issue #129

### DIFF
--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -1116,6 +1116,10 @@ def pick_by(obj, iteratee=None):
     """
     obj = to_dict(obj)
 
+    if iteratee is None:
+        iteratee = pyd.identity
+        argcount = 1
+
     if not callable(iteratee):
         paths = iteratee if iteratee is not None else []
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -485,7 +485,7 @@ def test_pick(case, expected):
     (({'a': 1, 'b': 2, 'c': 3}, ['a', 'b']), {'a': 1, 'b': 2}),
     (({'a': 1, 'b': 2, 'c': 3}, lambda value, key: key in ['a']),
      {'a': 1}),
-    (([1, 2, 3],), {}),
+    (([1, 2, 3],), {0: 1, 1: 2, 2: 3}),
     (([1, 2, 3], [0]), {0: 1}),
     ((fixtures.Object(a=1, b=2, c=3), 'a'), {'a': 1}),
     ((fixtures.ItemsObject({'a': 1, 'b': 2, 'c': 3}), 'a'), {'a': 1}),


### PR DESCRIPTION
Fixed pick_by function behavior: 
- When the **iteratee** is **None** the function uses **pyd.identity** as the **iteratee**. 
- Updated the test related to that function, with the case **iteratee = None**, and changed the expected return to a copy of the object.