### PR TITLE
Better get typing for basic list usage

### DIFF
--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -833,6 +833,21 @@ def for_in_right(obj, iteratee=None):
     return obj
 
 
+@t.overload
+def get(obj: t.List[T], path: int, default: T2) -> t.Union[T, T2]:
+    ...
+
+
+@t.overload
+def get(obj: t.List[T], path: int, default: None = None) -> t.Union[T, None]:
+    ...
+
+
+@t.overload
+def get(obj: t.Iterable, path: PathT, default: t.Any = None) -> t.Any:
+    ...
+
+
 def get(obj: t.Iterable, path: PathT, default: t.Any = None) -> t.Any:
     """
     Get the value at any depth of a nested object based on the path described by `path`. If path

--- a/tests/pytest_mypy_testing/test_objects.py
+++ b/tests/pytest_mypy_testing/test_objects.py
@@ -105,6 +105,8 @@ def test_mypy_get() -> None:
     reveal_type(_.get({}, 'a.b.c'))  # R: Any
     reveal_type(_.get({'a': {'b': {'c': [1, 2, 3, 4]}}}, 'a.b.c[1]'))  # R: Any
     reveal_type(_.get({'a': {'b': [0, {'c': [1, 2]}]}}, 'a.b.1.c.2'))  # R: Any
+    reveal_type(_.get(['a', 'b'], 0))  # R: Union[builtins.str, None]
+    reveal_type(_.get(['a', 'b'], 0, 'c'))  # R: builtins.str
 
 
 @pytest.mark.mypy_testing


### PR DESCRIPTION
`get` is very hard to type but a very nice simple usage of the function is to maybe get a value from a list without worrying about index errors, similarly to `get` method for `dict`.
Since using the function on a list with an `int` path is unequivocal, this usage can be typed. This is the goal of this PR.