### PR TITLE
Add objects function type support on any objects

### DIFF
--- a/src/pydash/chaining/all_funcs.pyi
+++ b/src/pydash/chaining/all_funcs.pyi
@@ -2200,10 +2200,10 @@ class AllFuncs:
         self: "Chain[t.List[T]]", path: int, default: None = None
     ) -> "Chain[t.Union[T, None]]": ...
     @t.overload
-    def get(self: "Chain[t.Iterable]", path: PathT, default: t.Any = None) -> "Chain[t.Any]": ...
-    def get(self: "Chain[t.Iterable]", path: PathT, default: t.Any = None) -> "Chain[t.Any]":
+    def get(self: "Chain[t.Any]", path: PathT, default: t.Any = None) -> "Chain[t.Any]": ...
+    def get(self: "Chain[t.Any]", path: PathT, default: t.Any = None) -> "Chain[t.Any]":
         return self._wrap(pyd.get)(path, default)
-    def has(self: "Chain[t.Iterable]", path: PathT) -> "Chain[bool]":
+    def has(self: "Chain[t.Any]", path: PathT) -> "Chain[bool]":
         return self._wrap(pyd.has)(path)
     @t.overload
     def invert(self: "Chain[t.Mapping[T, T2]]") -> "Chain[t.Dict[T2, T]]": ...
@@ -2229,9 +2229,13 @@ class AllFuncs:
     ) -> "Chain[t.Dict[T, t.List[int]]]": ...
     def invert_by(self, iteratee=None):
         return self._wrap(pyd.invert_by)(iteratee)
-    def invoke(self: "Chain[t.Dict]", path: PathT, *args: t.Any, **kwargs: t.Any) -> "Chain[t.Any]":
+    def invoke(self: "Chain[t.Any]", path: PathT, *args: t.Any, **kwargs: t.Any) -> "Chain[t.Any]":
         return self._wrap(pyd.invoke)(path, *args, **kwargs)
-    def keys(self: "Chain[t.Iterable[T]]") -> "Chain[t.List[T]]":
+    @t.overload
+    def keys(self: "Chain[t.Iterable[T]]") -> "Chain[t.List[T]]": ...
+    @t.overload
+    def keys(self: "Chain[t.Any]") -> "Chain[t.List]": ...
+    def keys(self):
         return self._wrap(pyd.keys)()
     @t.overload
     def map_keys(
@@ -2315,6 +2319,8 @@ class AllFuncs:
     def omit(self: "Chain[t.Mapping[T, T2]]", *properties: PathT) -> "Chain[t.Dict[T, T2]]": ...
     @t.overload
     def omit(self: "Chain[t.Iterable[T]]", *properties: PathT) -> "Chain[t.Dict[int, T]]": ...
+    @t.overload
+    def omit(self: "Chain[t.Any]", *properties: PathT) -> "Chain[t.Dict]": ...
     def omit(self, *properties):
         return self._wrap(pyd.omit)(*properties)
     @t.overload
@@ -2337,6 +2343,10 @@ class AllFuncs:
     ) -> "Chain[t.Dict[int, T]]": ...
     @t.overload
     def omit_by(self: "Chain[t.List[T]]", iteratee: None = None) -> "Chain[t.Dict[int, T]]": ...
+    @t.overload
+    def omit_by(
+        self: "Chain[t.Any]", iteratee: t.Union[t.Callable, None] = None
+    ) -> "Chain[t.Dict]": ...
     def omit_by(self, iteratee=None):
         return self._wrap(pyd.omit_by)(iteratee)
     def parse_int(
@@ -2348,7 +2358,9 @@ class AllFuncs:
     @t.overload
     def pick(
         self: "Chain[t.Union[t.Tuple[T, ...], t.List[T]]]", *properties: PathT
-    ) -> "Chain[t.List[T]]": ...
+    ) -> "Chain[t.Dict[int, T]]": ...
+    @t.overload
+    def pick(self: "Chain[t.Any]", *properties: PathT) -> "Chain[t.Dict]": ...
     def pick(self, *properties):
         return self._wrap(pyd.pick)(*properties)
     @t.overload
@@ -2364,42 +2376,32 @@ class AllFuncs:
     @t.overload
     def pick_by(
         self: "Chain[t.Union[t.Tuple[T, ...], t.List[T]]]", iteratee: t.Callable[[T, int], t.Any]
-    ) -> "Chain[t.List[T]]": ...
+    ) -> "Chain[t.Dict[int, T]]": ...
     @t.overload
     def pick_by(
         self: "Chain[t.Union[t.Tuple[T, ...], t.List[T]]]", iteratee: t.Callable[[T], t.Any]
-    ) -> "Chain[t.List[T]]": ...
+    ) -> "Chain[t.Dict[int, T]]": ...
     @t.overload
-    def pick_by(self: "Chain[t.List[T]]", iteratee: None = None) -> "Chain[t.Dict[int, T]]": ...
+    def pick_by(
+        self: "Chain[t.Union[t.Tuple[T, ...], t.List[T]]]", iteratee: None = None
+    ) -> "Chain[t.Dict[int, T]]": ...
+    @t.overload
+    def pick_by(
+        self: "Chain[t.Any]", iteratee: t.Union[t.Callable, None] = None
+    ) -> "Chain[t.Dict]": ...
     def pick_by(self, iteratee=None):
         return self._wrap(pyd.pick_by)(iteratee)
     def rename_keys(
         self: "Chain[t.Dict[T, T2]]", key_map: t.Dict[t.Any, T3]
     ) -> "Chain[t.Dict[t.Union[T, T3], T2]]":
         return self._wrap(pyd.rename_keys)(key_map)
-    @t.overload
-    def set_(self: "Chain[t.List]", path: PathT, value: t.Any) -> "Chain[t.List]": ...
-    @t.overload
-    def set_(self: "Chain[t.Dict]", path: PathT, value: t.Any) -> "Chain[t.Dict]": ...
-    def set_(self, path, value):
+    def set_(self: "Chain[T]", path: PathT, value: t.Any) -> "Chain[T]":
         return self._wrap(pyd.set_)(path, value)
     set = set_
 
-    @t.overload
     def set_with(
-        self: "Chain[t.List]",
-        path: PathT,
-        value: t.Any,
-        customizer: t.Union[t.Callable, None] = None,
-    ) -> "Chain[t.List]": ...
-    @t.overload
-    def set_with(
-        self: "Chain[t.Dict]",
-        path: PathT,
-        value: t.Any,
-        customizer: t.Union[t.Callable, None] = None,
-    ) -> "Chain[t.Dict]": ...
-    def set_with(self, path, value, customizer=None):
+        self: "Chain[T]", path: PathT, value: t.Any, customizer: t.Union[t.Callable, None] = None
+    ) -> "Chain[T]":
         return self._wrap(pyd.set_with)(path, value, customizer)
     def to_boolean(
         self: "Chain[t.Any]",
@@ -2412,7 +2414,7 @@ class AllFuncs:
     @t.overload
     def to_dict(self: "Chain[t.List[t.Tuple[T, T2]]]") -> "Chain[t.Dict[T, T2]]": ...
     @t.overload
-    def to_dict(self: "Chain[t.Iterable]") -> "Chain[t.Dict]": ...
+    def to_dict(self: "Chain[t.Any]") -> "Chain[t.Dict]": ...
     def to_dict(self):
         return self._wrap(pyd.to_dict)()
     def to_integer(self: "Chain[t.Any]") -> "Chain[int]":
@@ -2433,6 +2435,8 @@ class AllFuncs:
     def to_pairs(self: "Chain[t.Mapping[T, T2]]") -> "Chain[t.List[t.List[t.Union[T, T2]]]]": ...
     @t.overload
     def to_pairs(self: "Chain[t.Iterable[T]]") -> "Chain[t.List[t.List[t.Union[int, T]]]]": ...
+    @t.overload
+    def to_pairs(self: "Chain[t.Any]") -> "Chain[t.List]": ...
     def to_pairs(self):
         return self._wrap(pyd.to_pairs)()
     @t.overload
@@ -2479,17 +2483,19 @@ class AllFuncs:
         return self._wrap(pyd.transform)(iteratee, accumulator)
     @t.overload
     def update(
-        self: "Chain[t.Mapping[t.Any, T2]]", path: PathT, updater: t.Callable[[T2], t.Any]
+        self: "Chain[t.Dict[t.Any, T2]]", path: PathT, updater: t.Callable[[T2], t.Any]
     ) -> "Chain[t.Dict]": ...
     @t.overload
     def update(
         self: "Chain[t.List[T]]", path: PathT, updater: t.Callable[[T], t.Any]
     ) -> "Chain[t.List]": ...
+    @t.overload
+    def update(self: "Chain[T]", path: PathT, updater: t.Callable) -> "Chain[T]": ...
     def update(self, path, updater):
         return self._wrap(pyd.update)(path, updater)
     @t.overload
     def update_with(
-        self: "Chain[t.Mapping[t.Any, T2]]",
+        self: "Chain[t.Dict[t.Any, T2]]",
         path: PathT,
         updater: t.Callable[[T2], t.Any],
         customizer: t.Union[t.Callable, None],
@@ -2501,6 +2507,13 @@ class AllFuncs:
         updater: t.Callable[[T], t.Any],
         customizer: t.Union[t.Callable, None] = None,
     ) -> "Chain[t.List]": ...
+    @t.overload
+    def update_with(
+        self: "Chain[T]",
+        path: PathT,
+        updater: t.Callable,
+        customizer: t.Union[t.Callable, None] = None,
+    ) -> "Chain[T]": ...
     def update_with(self, path, updater, customizer=None):
         return self._wrap(pyd.update_with)(path, updater, customizer)
     def unset(self: "Chain[t.Union[t.List, t.Dict]]", path: PathT) -> "Chain[bool]":
@@ -2509,6 +2522,8 @@ class AllFuncs:
     def values(self: "Chain[t.Mapping[t.Any, T2]]") -> "Chain[t.List[T2]]": ...
     @t.overload
     def values(self: "Chain[t.Iterable[T]]") -> "Chain[t.List[T]]": ...
+    @t.overload
+    def values(self: "Chain[t.Any]") -> "Chain[t.List]": ...
     def values(self):
         return self._wrap(pyd.values)()
     def eq(self: "Chain[t.Any]", other: t.Any) -> "Chain[bool]":

--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -844,11 +844,11 @@ def get(obj: t.List[T], path: int, default: None = None) -> t.Union[T, None]:
 
 
 @t.overload
-def get(obj: t.Iterable, path: PathT, default: t.Any = None) -> t.Any:
+def get(obj: t.Any, path: PathT, default: t.Any = None) -> t.Any:
     ...
 
 
-def get(obj: t.Iterable, path: PathT, default: t.Any = None) -> t.Any:
+def get(obj: t.Any, path: PathT, default: t.Any = None) -> t.Any:
     """
     Get the value at any depth of a nested object based on the path described by `path`. If path
     doesn't exist, `default` is returned.
@@ -918,7 +918,7 @@ def get(obj: t.Iterable, path: PathT, default: t.Any = None) -> t.Any:
     return obj
 
 
-def has(obj: t.Iterable, path: PathT) -> bool:
+def has(obj: t.Any, path: PathT) -> bool:
     """
     Checks if `path` exists as a key of `obj`.
 
@@ -1067,7 +1067,7 @@ def invert_by(obj, iteratee=None):
     return result
 
 
-def invoke(obj: t.Dict, path: PathT, *args: t.Any, **kwargs: t.Any) -> t.Any:
+def invoke(obj: t.Any, path: PathT, *args: t.Any, **kwargs: t.Any) -> t.Any:
     """
     Invokes the method at path of object.
 
@@ -1105,7 +1105,17 @@ def invoke(obj: t.Dict, path: PathT, *args: t.Any, **kwargs: t.Any) -> t.Any:
     return ret
 
 
+@t.overload
 def keys(obj: t.Iterable[T]) -> t.List[T]:
+    ...
+
+
+@t.overload
+def keys(obj: t.Any) -> t.List:
+    ...
+
+
+def keys(obj):
     """
     Creates a list composed of the keys of `obj`.
 
@@ -1455,6 +1465,11 @@ def omit(obj: t.Iterable[T], *properties: PathT) -> t.Dict[int, T]:
     ...
 
 
+@t.overload
+def omit(obj: t.Any, *properties: PathT) -> t.Dict:
+    ...
+
+
 def omit(obj, *properties):
     """
     The opposite of :func:`pick`. This method creates an object composed of the property paths of
@@ -1516,6 +1531,11 @@ def omit_by(obj: t.Iterable[T], iteratee: t.Callable[[T], t.Any]) -> t.Dict[int,
 
 @t.overload
 def omit_by(obj: t.List[T], iteratee: None = None) -> t.Dict[int, T]:
+    ...
+
+
+@t.overload
+def omit_by(obj: t.Any, iteratee: t.Union[t.Callable, None] = None) -> t.Dict:
     ...
 
 
@@ -1620,7 +1640,12 @@ def pick(obj: t.Mapping[T, T2], *properties: PathT) -> t.Dict[T, T2]:
 
 
 @t.overload
-def pick(obj: t.Union[t.Tuple[T, ...], t.List[T]], *properties: PathT) -> t.List[T]:
+def pick(obj: t.Union[t.Tuple[T, ...], t.List[T]], *properties: PathT) -> t.Dict[int, T]:
+    ...
+
+
+@t.overload
+def pick(obj: t.Any, *properties: PathT) -> t.Dict:
     ...
 
 
@@ -1666,19 +1691,24 @@ def pick_by(obj: t.Dict[T, T2], iteratee: None = None) -> t.Dict[T, T2]:
 @t.overload
 def pick_by(
     obj: t.Union[t.Tuple[T, ...], t.List[T]], iteratee: t.Callable[[T, int], t.Any]
-) -> t.List[T]:
+) -> t.Dict[int, T]:
     ...
 
 
 @t.overload
 def pick_by(
     obj: t.Union[t.Tuple[T, ...], t.List[T]], iteratee: t.Callable[[T], t.Any]
-) -> t.List[T]:
+) -> t.Dict[int, T]:
     ...
 
 
 @t.overload
-def pick_by(obj: t.List[T], iteratee: None = None) -> t.Dict[int, T]:
+def pick_by(obj: t.Union[t.Tuple[T, ...], t.List[T]], iteratee: None = None) -> t.Dict[int, T]:
+    ...
+
+
+@t.overload
+def pick_by(obj: t.Any, iteratee: t.Union[t.Callable, None] = None) -> t.Dict:
     ...
 
 
@@ -1753,17 +1783,7 @@ def rename_keys(obj: t.Dict[T, T2], key_map: t.Dict[t.Any, T3]) -> t.Dict[t.Unio
     return {key_map.get(key, key): value for key, value in obj.items()}
 
 
-@t.overload
-def set_(obj: t.List, path: PathT, value: t.Any) -> t.List:
-    ...
-
-
-@t.overload
-def set_(obj: t.Dict, path: PathT, value: t.Any) -> t.Dict:
-    ...
-
-
-def set_(obj, path, value):
+def set_(obj: T, path: PathT, value: t.Any) -> T:
     """
     Sets the value of an object described by `path`. If any part of the object path doesn't exist,
     it will be created.
@@ -1805,27 +1825,7 @@ def set_(obj, path, value):
     return set_with(obj, path, value)
 
 
-@t.overload
-def set_with(
-    obj: t.List,
-    path: PathT,
-    value: t.Any,
-    customizer: t.Union[t.Callable, None] = None,
-) -> t.List:
-    ...
-
-
-@t.overload
-def set_with(
-    obj: t.Dict,
-    path: PathT,
-    value: t.Any,
-    customizer: t.Union[t.Callable, None] = None,
-) -> t.Dict:
-    ...
-
-
-def set_with(obj, path, value, customizer=None):
+def set_with(obj: T, path: PathT, value: t.Any, customizer: t.Union[t.Callable, None] = None) -> T:
     """
     This method is like :func:`set_` except that it accepts customizer which is invoked to produce
     the objects of path. If customizer returns undefined path creation is handled by the method
@@ -1925,7 +1925,7 @@ def to_dict(obj: t.List[t.Tuple[T, T2]]) -> t.Dict[T, T2]:
 
 
 @t.overload
-def to_dict(obj: t.Iterable) -> t.Dict:
+def to_dict(obj: t.Any) -> t.Dict:
     ...
 
 
@@ -2124,6 +2124,11 @@ def to_pairs(obj: t.Iterable[T]) -> t.List[t.List[t.Union[int, T]]]:
     ...
 
 
+@t.overload
+def to_pairs(obj: t.Any) -> t.List:
+    ...
+
+
 def to_pairs(obj):
     """
     Creates a two dimensional list of an object's key-value pairs, i.e. ``[[key1, value1], [key2,
@@ -2284,7 +2289,7 @@ def transform(obj, iteratee=None, accumulator=None):
 
 @t.overload
 def update(
-    obj: t.Mapping[t.Any, T2],
+    obj: t.Dict[t.Any, T2],
     path: PathT,
     updater: t.Callable[[T2], t.Any],
 ) -> t.Dict:
@@ -2297,6 +2302,15 @@ def update(
     path: PathT,
     updater: t.Callable[[T], t.Any],
 ) -> t.List:
+    ...
+
+
+@t.overload
+def update(
+    obj: T,
+    path: PathT,
+    updater: t.Callable,
+) -> T:
     ...
 
 
@@ -2331,7 +2345,7 @@ def update(obj, path, updater):
 
 @t.overload
 def update_with(
-    obj: t.Mapping[t.Any, T2],
+    obj: t.Dict[t.Any, T2],
     path: PathT,
     updater: t.Callable[[T2], t.Any],
     customizer: t.Union[t.Callable, None],
@@ -2346,6 +2360,16 @@ def update_with(
     updater: t.Callable[[T], t.Any],
     customizer: t.Union[t.Callable, None] = None,
 ) -> t.List:
+    ...
+
+
+@t.overload
+def update_with(
+    obj: T,
+    path: PathT,
+    updater: t.Callable,
+    customizer: t.Union[t.Callable, None] = None,
+) -> T:
     ...
 
 
@@ -2514,6 +2538,11 @@ def values(obj: t.Mapping[t.Any, T2]) -> t.List[T2]:
 
 @t.overload
 def values(obj: t.Iterable[T]) -> t.List[T]:
+    ...
+
+
+@t.overload
+def values(obj: t.Any) -> t.List:
     ...
 
 

--- a/tests/pytest_mypy_testing/test_objects.py
+++ b/tests/pytest_mypy_testing/test_objects.py
@@ -5,6 +5,15 @@ import pytest
 import pydash as _
 
 
+class MyClass:
+    def __init__(self) -> None:
+        self.x = 5
+        self.lst: t.List[int] = []
+
+    def get_x(self) -> int:
+        return self.x
+
+
 @pytest.mark.mypy_testing
 def test_mypy_assign() -> None:
     obj = {b'd': 5.5}
@@ -107,12 +116,14 @@ def test_mypy_get() -> None:
     reveal_type(_.get({'a': {'b': [0, {'c': [1, 2]}]}}, 'a.b.1.c.2'))  # R: Any
     reveal_type(_.get(['a', 'b'], 0))  # R: Union[builtins.str, None]
     reveal_type(_.get(['a', 'b'], 0, 'c'))  # R: builtins.str
+    reveal_type(_.get(MyClass(), 'x'))  # R: Any
 
 
 @pytest.mark.mypy_testing
 def test_mypy_has() -> None:
     reveal_type(_.has([1, 2, 3], 1))  # R: builtins.bool
     reveal_type(_.has({'a': 1, 'b': 2}, 'b'))  # R: builtins.bool
+    reveal_type(_.has(MyClass(), 'get_x'))  # R: builtins.bool
 
 
 @pytest.mark.mypy_testing
@@ -135,12 +146,14 @@ def test_mypy_invert_by() -> None:
 def test_mypy_invoke() -> None:
     obj = {'a': [{'b': {'c': [1, 2, 3, 4]}}]}
     reveal_type(_.invoke(obj, 'a[0].b.c.pop', 1))  # R: Any
+    reveal_type(_.invoke(MyClass(), 'get_x'))  # R: Any
 
 
 @pytest.mark.mypy_testing
 def test_mypy_keys() -> None:
     reveal_type(_.keys([1, 2, 3]))  # R: builtins.list[builtins.int]
     reveal_type(_.keys({'a': 1, 'b': 2}))  # R: builtins.list[builtins.str]
+    reveal_type(_.keys(MyClass()))  # R: builtins.list[Any]
 
 
 @pytest.mark.mypy_testing
@@ -190,6 +203,7 @@ def test_mypy_omit() -> None:
     reveal_type(_.omit({'a': 1, 'b': 2, 'c': 3 }, ['a', 'c']))  # R: builtins.dict[builtins.str, builtins.int]
     reveal_type(_.omit([1, 2, 3, 4], 0, 3))  # R: builtins.dict[builtins.int, builtins.int]
     reveal_type(_.omit({'a': {'b': {'c': 'd'}}}, 'a.b.c'))  # R: builtins.dict[builtins.str, builtins.dict[builtins.str, builtins.dict[builtins.str, builtins.str]]]
+    reveal_type(_.omit(MyClass(), 'x'))  # R: builtins.dict[Any, Any]
 
 
 @pytest.mark.mypy_testing
@@ -200,6 +214,7 @@ def test_mypy_omit_by() -> None:
     obj: t.Dict[str, t.Union[str, int]] = {'a': 1, 'b': '2', 'c': 3}
     reveal_type(_.omit_by(obj, is_int))  # R: builtins.dict[builtins.str, Union[builtins.str, builtins.int]]
     reveal_type(_.omit_by([1, 2, 3, 4], is_int))  # R: builtins.dict[builtins.int, builtins.int]
+    reveal_type(_.omit_by(MyClass(), is_int))  # R: builtins.dict[Any, Any]
 
 
 @pytest.mark.mypy_testing
@@ -211,6 +226,7 @@ def test_mypy_parse_int() -> None:
 @pytest.mark.mypy_testing
 def test_mypy_pick() -> None:
     reveal_type(_.pick({'a': 1, 'b': 2, 'c': 3}, 'a', 'b'))  # R: builtins.dict[builtins.str, builtins.int]
+    reveal_type(_.pick(MyClass(), 'x'))  # R: builtins.dict[Any, Any]
 
 
 @pytest.mark.mypy_testing
@@ -221,6 +237,7 @@ def test_mypy_pick_by() -> None:
     obj: t.Dict[str, t.Union[int, str]] = {'a': 1, 'b': '2', 'c': 3 }
 
     reveal_type(_.pick_by(obj, is_int))  # R: builtins.dict[builtins.str, Union[builtins.int, builtins.str]]
+    reveal_type(_.pick(MyClass(), lambda v: isinstance(v, int)))  # R: builtins.dict[Any, Any]
 
 
 @pytest.mark.mypy_testing
@@ -230,12 +247,14 @@ def test_mypy_rename_keys() -> None:
 
 @pytest.mark.mypy_testing
 def test_mypy_set_() -> None:
-    reveal_type(_.set_({}, 'a.b.c', 1))  # R: builtins.dict[Any, Any]
+    reveal_type(_.set_({}, 'a.b.c', 1))  # R: builtins.dict[<nothing>, <nothing>]
+    reveal_type(_.set_(MyClass(), "x", 10))  # R: tests.pytest_mypy_testing.test_objects.MyClass
 
 
 @pytest.mark.mypy_testing
 def test_mypy_set_with() -> None:
-    reveal_type(_.set_with({}, '[0][1]', 'a', lambda: {}))  # R: builtins.dict[Any, Any]
+    reveal_type(_.set_with({}, '[0][1]', 'a', lambda: {}))  # R: builtins.dict[<nothing>, <nothing>]
+    reveal_type(_.set_with(MyClass(), "x", lambda: 10))  # R: tests.pytest_mypy_testing.test_objects.MyClass
 
 
 @pytest.mark.mypy_testing
@@ -247,6 +266,7 @@ def test_mypy_to_boolean() -> None:
 def test_mypy_to_dict() -> None:
     obj = {'a': 1, 'b': 2}
     reveal_type(_.to_dict(obj))  # R: builtins.dict[builtins.str, builtins.int]
+    reveal_type(_.to_dict(MyClass()))  # R: builtins.dict[Any, Any]
 
 
 @pytest.mark.mypy_testing
@@ -278,6 +298,7 @@ def test_mypy_to_number() -> None:
 def test_mypy_to_pairs() -> None:
     reveal_type(_.to_pairs([1, 2, 3, 4]))  # R: builtins.list[builtins.list[builtins.int]]
     reveal_type(_.to_pairs({'a': 1}))  # R: builtins.list[builtins.list[Union[builtins.str, builtins.int]]]
+    reveal_type(_.to_pairs(MyClass()))  # R: builtins.list[Any]
 
 
 @pytest.mark.mypy_testing
@@ -301,12 +322,14 @@ def test_mypy_transform() -> None:
 def test_mypy_update() -> None:
     reveal_type(_.update({}, ['a', 'b'], lambda value: value))  # R: builtins.dict[Any, Any]
     reveal_type(_.update([], [0, 0], lambda value: 1))  # R: builtins.list[Any]
+    reveal_type(_.update(MyClass(), 'x', lambda value: 10))  # R: tests.pytest_mypy_testing.test_objects.MyClass
 
 
 @pytest.mark.mypy_testing
 def test_mypy_update_with() -> None:
     reveal_type(_.update_with({}, '[0][1]', lambda x: 'a', lambda x: {}))  # R: builtins.dict[Any, Any]
     reveal_type(_.update_with([], [0, 0], lambda x: 1, lambda x: []))  # R: builtins.list[Any]
+    reveal_type(_.update_with(MyClass(), 'lst.0', lambda value: 10, lambda x: []))  # R: tests.pytest_mypy_testing.test_objects.MyClass
 
 
 @pytest.mark.mypy_testing
@@ -319,3 +342,4 @@ def test_mypy_values() -> None:
     reveal_type(_.values({'a': 'a', 'b': 'b', 'c': 'c'}))  # R: builtins.list[builtins.str]
     reveal_type(_.values({'a': 1, 'b': 2, 'c': 3}))  # R: builtins.list[builtins.int]
     reveal_type(_.values([2, 4, 6, 8]))  # R: builtins.list[builtins.int]
+    reveal_type(_.values(MyClass()))  # R: builtins.list[Any]


### PR DESCRIPTION
As you realized there https://github.com/dgilland/pydash/pull/183, this aims to fix the functions that can be applied on any objects.
It includes `get` and the functions using it but I also found a few other ones in the `objects` module like the `set_` and `update` families.
