### PR TITLE
Type fixes

### DIFF
--- a/src/pydash/arrays.py
+++ b/src/pydash/arrays.py
@@ -2294,7 +2294,9 @@ def uniq(array: t.Iterable[T]) -> t.List[T]:
     return uniq_by(array)
 
 
-def uniq_by(array: t.Iterable[T], iteratee: t.Union[t.Callable[[T], T], None] = None) -> t.List[T]:
+def uniq_by(
+    array: t.Iterable[T], iteratee: t.Union[t.Callable[[T], t.Any], None] = None
+) -> t.List[T]:
     """
     This method is like :func:`uniq` except that it accepts iteratee which is invoked for each
     element in array to generate the criterion by which uniqueness is computed. The order of result

--- a/src/pydash/chaining/all_funcs.pyi
+++ b/src/pydash/chaining/all_funcs.pyi
@@ -476,7 +476,7 @@ class AllFuncs:
     def uniq(self: "Chain[t.Iterable[T]]") -> "Chain[t.List[T]]":
         return self._wrap(pyd.uniq)()
     def uniq_by(
-        self: "Chain[t.Iterable[T]]", iteratee: t.Union[t.Callable[[T], T], None] = None
+        self: "Chain[t.Iterable[T]]", iteratee: t.Union[t.Callable[[T], t.Any], None] = None
     ) -> "Chain[t.List[T]]":
         return self._wrap(pyd.uniq_by)(iteratee)
     def uniq_with(

--- a/tests/pytest_mypy_testing/test_arrays.py
+++ b/tests/pytest_mypy_testing/test_arrays.py
@@ -383,6 +383,7 @@ def test_mypy_uniq() -> None:
 @pytest.mark.mypy_testing
 def test_mypy_uniq_by() -> None:
     reveal_type(_.uniq_by([1, 2, 3, 1, 2, 3], lambda val: val % 2))  # R: builtins.list[builtins.int]
+    reveal_type(_.uniq_by([{"hello": 1}, {"hello": 1}], lambda val: val["hello"]))  # R: builtins.list[builtins.dict[builtins.str, builtins.int]]
 
 
 @pytest.mark.mypy_testing


### PR DESCRIPTION
This adds a typing fix:

* `uniq_by` iteratee return type had wrong type, it can be `Any` to be able to get unique list based on some sub values of the elements
