### PR TITLE
Type fixes

### DIFF
--- a/src/pydash/arrays.py
+++ b/src/pydash/arrays.py
@@ -2498,13 +2498,17 @@ def xor(array: t.Iterable[T], *lists: t.Iterable[T]) -> t.List[T]:
 
 @t.overload
 def xor_by(
-    array: t.Iterable[T], *lists: t.Iterable[T], iteratee: t.Union[t.Callable[[T], T], IterateeObjT]
+    array: t.Iterable[T],
+    *lists: t.Iterable[T],
+    iteratee: t.Union[t.Callable[[T], t.Any], IterateeObjT],
 ) -> t.List[T]:
     ...
 
 
 @t.overload
-def xor_by(array: t.Iterable[T], *lists: t.Union[t.Iterable[T], t.Callable[[T], T]]) -> t.List[T]:
+def xor_by(
+    array: t.Iterable[T], *lists: t.Union[t.Iterable[T], t.Callable[[T], t.Any]]
+) -> t.List[T]:
     ...
 
 

--- a/src/pydash/chaining/all_funcs.pyi
+++ b/src/pydash/chaining/all_funcs.pyi
@@ -511,11 +511,11 @@ class AllFuncs:
     def xor_by(
         self: "Chain[t.Iterable[T]]",
         *lists: t.Iterable[T],
-        iteratee: t.Union[t.Callable[[T], T], IterateeObjT]
+        iteratee: t.Union[t.Callable[[T], t.Any], IterateeObjT]
     ) -> "Chain[t.List[T]]": ...
     @t.overload
     def xor_by(
-        self: "Chain[t.Iterable[T]]", *lists: t.Union[t.Iterable[T], t.Callable[[T], T]]
+        self: "Chain[t.Iterable[T]]", *lists: t.Union[t.Iterable[T], t.Callable[[T], t.Any]]
     ) -> "Chain[t.List[T]]": ...
     def xor_by(self, *lists, **kwargs):
         return self._wrap(pyd.xor_by)(*lists, **kwargs)

--- a/tests/pytest_mypy_testing/test_arrays.py
+++ b/tests/pytest_mypy_testing/test_arrays.py
@@ -433,6 +433,8 @@ def test_mypy_xor_by() -> None:
     reveal_type(_.xor_by([2.1, 1.2], [2.3, 3.4], round))  # R: builtins.list[builtins.float]
     reveal_type(_.xor_by([{'x': 1}], [{'x': 2}, {'x': 1}], iteratee='x'))  # R: builtins.list[builtins.dict[builtins.str, builtins.int]]
 
+    reveal_type(_.xor_by([{"hello": 1}], [{"hello": 2}], lambda d: d["hello"]))  # R: builtins.list[builtins.dict[builtins.str, builtins.int]]
+
 
 @pytest.mark.mypy_testing
 def test_mypy_xor_with() -> None:


### PR DESCRIPTION
The iteratee of all these functions should be able to return `Any` type so that the criterion can be any subvalue of the elements.

The other `_by` functions seem fine. It is the `arrays` one that had this problem.