### PR TITLE
fix(deps): exclude buggy typing-extensions 4.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ packages = find:
 python_requires = >=3.7
 include_package_data = True
 install_requires =
-    typing-extensions>=3.10
+    typing-extensions>=3.10,!=4.6.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
That’s to avoid that a user accidentally (through other deps) installs the incompatible/buggy typing-extensions package [v4.6.0](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-460-may-22-2023), see also issue https://github.com/dgilland/pydash/issues/197.

This should be a bug-fix release for pydash (assuming that pydash follows [SemVer](https://semver.org/)) so that other packages which depend on pydash can respond accordingly.