### PR TITLE
Correct function overloading for map_keys

### DIFF
--- a/src/pydash/chaining/all_funcs.pyi
+++ b/src/pydash/chaining/all_funcs.pyi
@@ -2310,7 +2310,7 @@ class AllFuncs:
     ) -> "Chain[t.Dict[T3, T2]]": ...
     @t.overload
     def map_keys(
-        self: "Chain[t.Mapping[t.Any, T2]]", iteratee: t.Callable[[T2], T3]
+        self: "Chain[t.Mapping[T, T2]]", iteratee: t.Callable[[T], T3]
     ) -> "Chain[t.Dict[T3, T2]]": ...
     @t.overload
     def map_keys(


### PR DESCRIPTION
There is a small bug in `Chain.map_keys`. When the iteratee accepts only one argument, the type of the argument is said to be of type `T2`, which is the type of the values. However since `map_keys` well, maps keys, the type here should be `T`. This commit should fix that.