### PR TITLE
Fix path behaviour for set_ 

### DIFF
--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -2295,9 +2295,6 @@ def update_with(obj, path, updater, customizer=None):  # noqa: C901
     default_type = dict if isinstance(obj, dict) else list
     tokens = to_path_tokens(path)
 
-    if not pyd.is_list(tokens):  # pragma: no cover
-        tokens = [tokens]
-
     last_key = pyd.last(tokens)
 
     if isinstance(last_key, PathToken):
@@ -2367,9 +2364,6 @@ def unset(obj: t.Union[t.List, t.Dict], path: PathT) -> bool:  # noqa: C901
     """
     tokens = to_path_tokens(path)
 
-    if not pyd.is_list(tokens):  # pragma: no cover
-        tokens = [tokens]
-
     last_key = pyd.last(tokens)
 
     if isinstance(last_key, PathToken):
@@ -2397,10 +2391,12 @@ def unset(obj: t.Union[t.List, t.Dict], path: PathT) -> bool:  # noqa: C901
     if target is not UNSET:
         try:
             try:
-                target.pop(last_key)
+                # last_key can be a lot of things
+                # safe as everything wrapped in try/except
+                target.pop(last_key)  # type: ignore
                 did_unset = True
             except TypeError:
-                target.pop(int(last_key))
+                target.pop(int(last_key))  # type: ignore
                 did_unset = True
         except Exception:
             pass

--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -2309,7 +2309,7 @@ def update_with(obj, path, updater, customizer=None):  # noqa: C901
         if isinstance(token, PathToken):
             key = token.key
             default_factory = pyd.get(tokens, [idx + 1, "default_factory"], default=default_type)
-        else:
+        else:  # pragma: no cover
             key = token
             default_factory = default_type
 
@@ -2384,7 +2384,7 @@ def unset(obj: t.Union[t.List, t.Dict], path: PathT) -> bool:  # noqa: C901
     for token in pyd.initial(tokens):
         if isinstance(token, PathToken):
             key = token.key
-        else:
+        else:  # pragma: no cover
             key = token
 
         try:

--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -2306,12 +2306,8 @@ def update_with(obj, path, updater, customizer=None):  # noqa: C901
     target = obj
 
     for idx, token in enumerate(pyd.initial(tokens)):
-        if isinstance(token, PathToken):
-            key = token.key
-            default_factory = pyd.get(tokens, [idx + 1, "default_factory"], default=default_type)
-        else:  # pragma: no cover
-            key = token
-            default_factory = default_type
+        key = token.key
+        default_factory = pyd.get(tokens, [idx + 1, "default_factory"], default=default_type)
 
         obj_val = base_get(target, key, default=None)
         path_obj = None
@@ -2382,10 +2378,7 @@ def unset(obj: t.Union[t.List, t.Dict], path: PathT) -> bool:  # noqa: C901
     target = obj
 
     for token in pyd.initial(tokens):
-        if isinstance(token, PathToken):
-            key = token.key
-        else:  # pragma: no cover
-            key = token
+        key = token.key
 
         try:
             try:

--- a/src/pydash/utilities.py
+++ b/src/pydash/utilities.py
@@ -1378,13 +1378,7 @@ def to_path(value: PathT) -> t.List[t.Hashable]:
     .. versionchanged:: 4.2.1
         Ensure returned path is always a list.
     """
-    tokens = to_path_tokens(value)
-    if isinstance(tokens, list):
-        path = [
-            token.key if isinstance(token, PathToken) else token for token in to_path_tokens(value)
-        ]
-    else:
-        path = [tokens]
+    path = [token.key for token in to_path_tokens(value)]
     return path
 
 
@@ -1443,7 +1437,7 @@ def _to_path_token(key) -> PathToken:
     )
 
 
-def to_path_tokens(value):
+def to_path_tokens(value) -> list[PathToken]:
     """Parse `value` into :class:`PathToken` objects."""
     if pyd.is_string(value) and ("." in value or "[" in value):
         # Since we can't tell whether a bare number is supposed to be dict key or a list index, we
@@ -1457,7 +1451,7 @@ def to_path_tokens(value):
     elif pyd.is_list(value):
         keys = [_to_path_token(key) for key in value]
     else:
-        keys = value
+        keys = [_to_path_token(value)]
 
     return keys
 

--- a/src/pydash/utilities.py
+++ b/src/pydash/utilities.py
@@ -1437,7 +1437,7 @@ def _to_path_token(key) -> PathToken:
     )
 
 
-def to_path_tokens(value) -> list[PathToken]:
+def to_path_tokens(value) -> t.List[PathToken]:
     """Parse `value` into :class:`PathToken` objects."""
     if pyd.is_string(value) and ("." in value or "[" in value):
         # Since we can't tell whether a bare number is supposed to be dict key or a list index, we

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -760,6 +760,17 @@ def test_set_(case, expected):
     assert _.set_(*case) == expected
 
 
+def test_set_on_class_works_the_same_with_string_and_list():
+    class A:
+        def __init__(self):
+            self.x = {}
+
+    a1 = A()
+    a2 = A()
+
+    assert _.set_(a1, "x.a.b", 1).x == _.set_(a2, ["x", "a", "b"], 1).x
+
+
 @parametrize(
     "case,expected",
     [


### PR DESCRIPTION
fixes #213

The default type when setting a missing key is usually given by the `PathToken` built in `to_path_tokens`.
However this function is incomplete and only builds a list of `PathToken`s if the path is a string.

The issue here is that that [line](https://github.com/dgilland/pydash/blob/develop/src/pydash/objects.py#L2408) sets the default type to `list` if the object to update is not a `dict`.
And as stated above, when we have a path as a list `to_path_tokens` just returns the list and we don't have any information about the default factory, we just default to `list`.
So when we create the first list and try to update it we expect an index.

This PR updates the `to_path_tokens` function to be more general and build the list of `PathToken` even for a list.

The added `pragma: no cover` are there because this case should now be impossible to reach, the only case where the tokens are not `PathToken`s is when the path is only 1 non string value and we go directly to the end case as the for loop only iterates on the initial values.