### PR TITLE
Add argcount to the function wrappers

### DIFF
--- a/src/pydash/functions.py
+++ b/src/pydash/functions.py
@@ -5,6 +5,7 @@ Functions that wrap other functions.
 """
 
 from inspect import getfullargspec
+from functools import cached_property
 import itertools
 import time
 import typing as t
@@ -54,7 +55,7 @@ P = ParamSpec("P")
 class _WithArgCount(Protocol):
     func: t.Callable
 
-    @property
+    @cached_property
     def _argcount(self) -> t.Optional[int]:
         return getargcount(self.func, None)
 
@@ -183,7 +184,7 @@ class Flow(t.Generic[P, T]):
         # type safety is ensured from the `__init__` signature
         return result  # type: ignore
 
-    @property
+    @cached_property
     def _argcount(self) -> t.Optional[int]:
         return getargcount(self.funcs[self._from_index], None)
 
@@ -233,7 +234,7 @@ class Curry(t.Generic[T1, T]):
         """Combine `self.args` with `new_args` and return."""
         return tuple(list(self.args) + list(new_args))
 
-    @property
+    @cached_property
     def _argcount(self) -> t.Optional[int]:
         argcount = self.arity - len(self.args) - len(self.kwargs)
         return argcount if argcount >= 0 else None
@@ -484,7 +485,7 @@ class Juxtapose(t.Generic[P, T]):
     def __call__(self, *objs: P.args, **kwargs: P.kwargs) -> t.List[T]:
         return [func(*objs, **kwargs) for func in self.funcs]
 
-    @property
+    @cached_property
     def _argcount(self) -> t.Optional[int]:
         return getargcount(self.funcs[0], None) if self.funcs else None
 
@@ -556,7 +557,7 @@ class Partial(_WithArgCount, t.Generic[T]):
 
         return self.func(*args, **kwargs)
 
-    @property
+    @cached_property
     def _argcount(self) -> t.Optional[int]:
         func_argcount = getargcount(self.func, None)
         if func_argcount is None:

--- a/src/pydash/functions.py
+++ b/src/pydash/functions.py
@@ -237,6 +237,11 @@ class Curry(t.Generic[T1, T]):
         """Combine `self.args` with `new_args` and return."""
         return tuple(list(self.args) + list(new_args))
 
+    @property
+    def _argcount(self) -> t.Optional[int]:
+        argcount = self.arity - len(self.args) - len(self.kwargs)
+        return argcount if argcount >= 0 else None
+
 
 class CurryOne(Curry[T1, T]):
     def __call__(self, arg_one: T1) -> T:

--- a/src/pydash/functions.py
+++ b/src/pydash/functions.py
@@ -4,8 +4,8 @@ Functions that wrap other functions.
 .. versionadded:: 1.0.0
 """
 
-from inspect import getfullargspec
 from functools import cached_property
+from inspect import getfullargspec
 import itertools
 import time
 import typing as t

--- a/src/pydash/functions.py
+++ b/src/pydash/functions.py
@@ -165,7 +165,7 @@ class Flow(t.Generic[P, T]):
 
     def __init__(self, *funcs, from_right: bool = True) -> None:  # type: ignore
         self.funcs = funcs
-        self.from_right = from_right
+        self._from_index = -1 if from_right else 0
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
         """Return results of composing :attr:`funcs`."""
@@ -182,10 +182,6 @@ class Flow(t.Generic[P, T]):
 
         # type safety is ensured from the `__init__` signature
         return result  # type: ignore
-
-    @property
-    def _from_index(self) -> int:
-        return -1 if self.from_right else 0
 
     @property
     def _argcount(self) -> t.Optional[int]:

--- a/src/pydash/helpers.py
+++ b/src/pydash/helpers.py
@@ -43,7 +43,11 @@ def getargcount(iteratee, maxargs):
     if hasattr(iteratee, "_argcount"):
         # Optimization feature where argcount of iteratee is known and properly
         # set by initiator.
-        return iteratee._argcount
+        # It should always be right, but it can be `None` for the function wrappers
+        # in `pydash.function` as the wrapped functions are out of our control and
+        # can support an unknown number of arguments.
+        argcount = iteratee._argcount
+        return argcount if argcount is not None else maxargs
 
     if isinstance(iteratee, type) or pyd.is_builtin(iteratee):
         # Only pass single argument to type iteratees or builtins.

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -410,6 +410,14 @@ def test_partial_right_argcount():
     assert _.partial_right(lambda x, y, z: x + y + z, 1, 2)._argcount == 1
 
 
+def test_curry_argcount():
+    assert _.curry(lambda x, y, z: x + y + z)(1)._argcount == 2
+
+
+def test_curry_right_argcount():
+    assert _.curry_right(lambda x, y, z: x + y + z)(1)._argcount == 2
+
+
 def test_can_be_used_as_predicate_argcount_is_known():
     def is_positive(x: int) -> bool:
         return x > 0

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -388,3 +388,30 @@ def test_unary(case, args, kwargs, expected):
 )
 def test_wrap(case, args, expected):
     assert _.wrap(*case)(*args) == expected
+
+
+def test_flow_argcount():
+    assert _.flow(lambda x, y: x + y, lambda x: x * 2)._argcount == 2
+
+
+def test_flow_right_argcount():
+    assert _.flow_right(lambda x: x * 2, lambda x, y: x + y)._argcount == 2
+
+
+def test_juxtapose_argcount():
+    assert _.juxtapose(lambda x, y, z: x + y + z, lambda x, y, z: x * y * z)._argcount == 3
+
+
+def test_partial_argcount():
+    assert _.partial(lambda x, y, z: x + y + z, 1, 2)._argcount == 1
+
+
+def test_partial_right_argcount():
+    assert _.partial_right(lambda x, y, z: x + y + z, 1, 2)._argcount == 1
+
+
+def test_can_be_used_as_predicate_argcount_is_known():
+    def is_positive(x: int) -> bool:
+        return x > 0
+
+    assert _.filter_([-1, 0, 1], _.negate(is_positive)) == [-1, 0]


### PR DESCRIPTION
fixes  #210

since we do not know in advance what the function will be in the functon wrappers, the `__call__` method is usually defined with the `(*args, **kwargs)` signature. however at runtime, when the wrapper is instanciated we know what the wrapped function is and we can return an argcount in most cases.

This PR adds the `_argcount` value to the function wrapper when possible, simply returning the argcount of the wrapped function when appropriate or with a few adjustments when needed. This way they can be used nicely with other functions that takes predicate like in the example in the issue linked above.