### PR TITLE
Fix call_math_operator on false values

### DIFF
--- a/src/pydash/numerical.py
+++ b/src/pydash/numerical.py
@@ -1210,10 +1210,10 @@ def zscore(collection, iteratee=None):
 
 def call_math_operator(value1, value2, op, default):
     """Return the result of the math operation on the given values."""
-    if not value1:
+    if value1 is None:
         value1 = default
 
-    if not value2:
+    if value2 is None:
         value2 = default
 
     if not pyd.is_number(value1):

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -200,7 +200,7 @@ def test_moving_mean(case, expected):
 
 @parametrize(
     "multiplier,multiplicand,expected",
-    [(10, 5, 50), (None, 1, 1), (None, None, 1), (1.5, 3, 4.5), (-10, 2, -20)],
+    [(10, 5, 50), (None, 1, 1), (None, None, 1), (1.5, 3, 4.5), (-10, 2, -20), (0, 1, 0)],
 )
 def test_multiply(multiplier, multiplicand, expected):
     assert _.multiply(multiplier, multiplicand) == expected

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -200,7 +200,15 @@ def test_moving_mean(case, expected):
 
 @parametrize(
     "multiplier,multiplicand,expected",
-    [(10, 5, 50), (None, 1, 1), (None, None, 1), (1.5, 3, 4.5), (-10, 2, -20), (0, 1, 0)],
+    [
+        (10, 5, 50),
+        (None, 1, 1),
+        (None, None, 1),
+        (1.5, 3, 4.5),
+        (-10, 2, -20),
+        (0, 1, 0),
+        (1, 0, 0),
+    ],
 )
 def test_multiply(multiplier, multiplicand, expected):
     assert _.multiply(multiplier, multiplicand) == expected


### PR DESCRIPTION
Fixes #217 

`0` is a `False` value hence checking for `not value` will return `True` and we will fallback to the default value.