### PR TITLE
Remove pytest version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,7 @@ dev = [
   "furo",
   "invoke",
   "mypy",
-  # pytest 8+ is not supported by pytest-mypy-testing
-  "pytest <8",
+  "pytest",
   "pytest-mypy-testing",
   "pytest-cov",
   "sphinx",


### PR DESCRIPTION
It was already fixed in a new release