### PR TITLE
Enable disallow any generics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ strict_optional = true
 warn_no_return = true
 warn_redundant_casts = false
 warn_unused_ignores = false
+disallow_any_generics = true
 
 [tool.pytest.ini_options]
 addopts = [

--- a/scripts/chaining_type_generator.py
+++ b/scripts/chaining_type_generator.py
@@ -68,9 +68,9 @@ T5 = t.TypeVar("T5")
 NumT = t.TypeVar("NumT", int, float, "Decimal")
 NumT2 = t.TypeVar("NumT2", int, float, "Decimal")
 NumT3 = t.TypeVar("NumT3", int, float, "Decimal")
-CallableT = t.TypeVar("CallableT", bound=t.Callable)
-SequenceT = t.TypeVar("SequenceT", bound=t.Sequence)
-MutableSequenceT = t.TypeVar("MutableSequenceT", bound=t.MutableSequence)
+CallableT = t.TypeVar("CallableT", bound=t.Callable[..., t.Any])
+SequenceT = t.TypeVar("SequenceT", bound=t.Sequence[t.Any])
+MutableSequenceT = t.TypeVar("MutableSequenceT", bound=t.MutableSequence[t.Any])
 P = ParamSpec("P")
 
 

--- a/src/pydash/arrays.py
+++ b/src/pydash/arrays.py
@@ -103,8 +103,8 @@ T2 = t.TypeVar("T2")
 T3 = t.TypeVar("T3")
 T4 = t.TypeVar("T4")
 T5 = t.TypeVar("T5")
-SequenceT = t.TypeVar("SequenceT", bound=t.Sequence)
-MutableSequenceT = t.TypeVar("MutableSequenceT", bound=t.MutableSequence)
+SequenceT = t.TypeVar("SequenceT", bound=t.Sequence[t.Any])
+MutableSequenceT = t.TypeVar("MutableSequenceT", bound=t.MutableSequence[t.Any])
 
 
 def chunk(array: t.Sequence[T], size: int = 1) -> t.List[t.Sequence[T]]:
@@ -664,7 +664,7 @@ def flatten(array):
     return flatten_depth(array, depth=1)
 
 
-def flatten_deep(array: t.Iterable) -> t.List:
+def flatten_deep(array: t.Iterable[t.Any]) -> t.List[t.Any]:
     """
     Flattens an array recursively.
 
@@ -684,7 +684,7 @@ def flatten_deep(array: t.Iterable) -> t.List:
     return flatten_depth(array, depth=-1)
 
 
-def flatten_depth(array: t.Iterable, depth: int = 1) -> t.List:
+def flatten_depth(array: t.Iterable[t.Any], depth: int = 1) -> t.List[t.Any]:
     """
     Recursively flatten `array` up to `depth` times.
 
@@ -2701,7 +2701,9 @@ def zip_object(keys, values=None):
     return dict(zip(keys, values))
 
 
-def zip_object_deep(keys: t.Iterable[t.Any], values: t.Union[t.List[t.Any], None] = None) -> t.Dict:
+def zip_object_deep(
+    keys: t.Iterable[t.Any], values: t.Union[t.List[t.Any], None] = None
+) -> t.Dict[t.Any, t.Any]:
     """
     This method is like :func:`zip_object` except that it supports property paths.
 
@@ -2723,7 +2725,7 @@ def zip_object_deep(keys: t.Iterable[t.Any], values: t.Union[t.List[t.Any], None
     if values is None:  # pragma: no cover
         keys, values = unzip(keys)
 
-    obj: t.Dict = {}
+    obj: t.Dict[t.Any, t.Any] = {}
     for idx, key in enumerate(keys):
         obj = pyd.set_(obj, key, pyd.get(values, idx))
 

--- a/src/pydash/chaining/all_funcs.pyi
+++ b/src/pydash/chaining/all_funcs.pyi
@@ -58,9 +58,9 @@ T5 = t.TypeVar("T5")
 NumT = t.TypeVar("NumT", int, float, "Decimal")
 NumT2 = t.TypeVar("NumT2", int, float, "Decimal")
 NumT3 = t.TypeVar("NumT3", int, float, "Decimal")
-CallableT = t.TypeVar("CallableT", bound=t.Callable)
-SequenceT = t.TypeVar("SequenceT", bound=t.Sequence)
-MutableSequenceT = t.TypeVar("MutableSequenceT", bound=t.MutableSequence)
+CallableT = t.TypeVar("CallableT", bound=t.Callable[..., t.Any])
+SequenceT = t.TypeVar("SequenceT", bound=t.Sequence[t.Any])
+MutableSequenceT = t.TypeVar("MutableSequenceT", bound=t.MutableSequence[t.Any])
 P = ParamSpec("P")
 
 class AllFuncs:
@@ -205,10 +205,10 @@ class AllFuncs:
     def flatten(self):
         return self._wrap(pyd.flatten)()
 
-    def flatten_deep(self: "Chain[t.Iterable]") -> "Chain[t.List]":
+    def flatten_deep(self: "Chain[t.Iterable[t.Any]]") -> "Chain[t.List[t.Any]]":
         return self._wrap(pyd.flatten_deep)()
 
-    def flatten_depth(self: "Chain[t.Iterable]", depth: int = 1) -> "Chain[t.List]":
+    def flatten_depth(self: "Chain[t.Iterable[t.Any]]", depth: int = 1) -> "Chain[t.List[t.Any]]":
         return self._wrap(pyd.flatten_depth)(depth)
 
     @t.overload
@@ -662,7 +662,7 @@ class AllFuncs:
 
     def zip_object_deep(
         self: "Chain[t.Iterable[t.Any]]", values: t.Union[t.List[t.Any], None] = None
-    ) -> "Chain[t.Dict]":
+    ) -> "Chain[t.Dict[t.Any, t.Any]]":
         return self._wrap(pyd.zip_object_deep)(values)
 
     @t.overload
@@ -927,29 +927,29 @@ class AllFuncs:
     def flat_map_deep(
         self: "Chain[t.Mapping[T, T2]]",
         iteratee: t.Union[t.Callable[[T2, T, t.Dict[T, T2]], t.Any], None] = None,
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_deep(
         self: "Chain[t.Mapping[T, T2]]", iteratee: t.Union[t.Callable[[T2, T], t.Any], None] = None
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_deep(
         self: "Chain[t.Mapping[t.Any, T2]]", iteratee: t.Union[t.Callable[[T2], t.Any], None] = None
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_deep(
         self: "Chain[t.Iterable[T]]",
         iteratee: t.Union[t.Callable[[T, int, t.List[T]], t.Any], None] = None,
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_deep(
         self: "Chain[t.Iterable[T]]", iteratee: t.Union[t.Callable[[T, int], t.Any], None] = None
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_deep(
         self: "Chain[t.Iterable[T]]", iteratee: t.Union[t.Callable[[T], t.Any], None] = None
-    ) -> "Chain[t.List]": ...
-    def flat_map_deep(self: "Chain[t.Iterable]", iteratee=None):
+    ) -> "Chain[t.List[t.Any]]": ...
+    def flat_map_deep(self, iteratee=None):
         return self._wrap(pyd.flat_map_deep)(iteratee)
 
     @t.overload
@@ -957,37 +957,37 @@ class AllFuncs:
         self: "Chain[t.Mapping[T, T2]]",
         iteratee: t.Union[t.Callable[[T2, T, t.Dict[T, T2]], t.Any], None] = None,
         depth: int = 1,
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_depth(
         self: "Chain[t.Mapping[T, T2]]",
         iteratee: t.Union[t.Callable[[T2, T], t.Any], None] = None,
         depth: int = 1,
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_depth(
         self: "Chain[t.Mapping[t.Any, T2]]",
         iteratee: t.Union[t.Callable[[T2], t.Any], None] = None,
         depth: int = 1,
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_depth(
         self: "Chain[t.Iterable[T]]",
         iteratee: t.Union[t.Callable[[T, int, t.List[T]], t.Any], None] = None,
         depth: int = 1,
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_depth(
         self: "Chain[t.Iterable[T]]",
         iteratee: t.Union[t.Callable[[T, int], t.Any], None] = None,
         depth: int = 1,
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def flat_map_depth(
         self: "Chain[t.Iterable[T]]",
         iteratee: t.Union[t.Callable[[T], t.Any], None] = None,
         depth: int = 1,
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     def flat_map_depth(self, iteratee=None, depth=1):
         return self._wrap(pyd.flat_map_depth)(iteratee, depth)
 
@@ -1065,12 +1065,14 @@ class AllFuncs:
         return self._wrap(pyd.group_by)(iteratee)
 
     def includes(
-        self: "Chain[t.Union[t.Sequence, t.Dict]]", target: t.Any, from_index: int = 0
+        self: "Chain[t.Union[t.Sequence[t.Any], t.Dict[t.Any, t.Any]]]",
+        target: t.Any,
+        from_index: int = 0,
     ) -> "Chain[bool]":
         return self._wrap(pyd.includes)(target, from_index)
 
     def invoke_map(
-        self: "Chain[t.Iterable]", path: PathT, *args: t.Any, **kwargs: t.Any
+        self: "Chain[t.Iterable[t.Any]]", path: PathT, *args: t.Any, **kwargs: t.Any
     ) -> "Chain[t.List[t.Any]]":
         return self._wrap(pyd.invoke_map)(path, *args, **kwargs)
 
@@ -1080,8 +1082,8 @@ class AllFuncs:
     ) -> "Chain[t.Dict[T2, T]]": ...
     @t.overload
     def key_by(
-        self: "Chain[t.Iterable]", iteratee: t.Union[IterateeObjT, None] = None
-    ) -> "Chain[t.Dict]": ...
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Union[IterateeObjT, None] = None
+    ) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     def key_by(self, iteratee=None):
         return self._wrap(pyd.key_by)(iteratee)
 
@@ -1118,7 +1120,7 @@ class AllFuncs:
 
     map = map_
 
-    def nest(self: "Chain[t.Iterable]", *properties: t.Any) -> "Chain[t.Any]":
+    def nest(self: "Chain[t.Iterable[t.Any]]", *properties: t.Any) -> "Chain[t.Any]":
         return self._wrap(pyd.nest)(*properties)
 
     @t.overload
@@ -1187,7 +1189,7 @@ class AllFuncs:
     def partition(self, predicate=None):
         return self._wrap(pyd.partition)(predicate)
 
-    def pluck(self: "Chain[t.Iterable]", path: PathT) -> "Chain[t.List]":
+    def pluck(self: "Chain[t.Iterable[t.Any]]", path: PathT) -> "Chain[t.List[t.Any]]":
         return self._wrap(pyd.pluck)(path)
 
     @t.overload
@@ -1200,7 +1202,7 @@ class AllFuncs:
     ) -> "Chain[T3]": ...
     @t.overload
     def reduce_(
-        self: "Chain[t.Mapping]", iteratee: t.Callable[[T3], T3], accumulator: T3
+        self: "Chain[t.Mapping[t.Any, t.Any]]", iteratee: t.Callable[[T3], T3], accumulator: T3
     ) -> "Chain[T3]": ...
     @t.overload
     def reduce_(
@@ -1216,7 +1218,9 @@ class AllFuncs:
     ) -> "Chain[T2]": ...
     @t.overload
     def reduce_(
-        self: "Chain[t.Mapping]", iteratee: t.Callable[[T], T], accumulator: None = None
+        self: "Chain[t.Mapping[t.Any, t.Any]]",
+        iteratee: t.Callable[[T], T],
+        accumulator: None = None,
     ) -> "Chain[T]": ...
     @t.overload
     def reduce_(
@@ -1228,7 +1232,7 @@ class AllFuncs:
     ) -> "Chain[T2]": ...
     @t.overload
     def reduce_(
-        self: "Chain[t.Iterable]", iteratee: t.Callable[[T2], T2], accumulator: T2
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Callable[[T2], T2], accumulator: T2
     ) -> "Chain[T2]": ...
     @t.overload
     def reduce_(
@@ -1240,7 +1244,7 @@ class AllFuncs:
     ) -> "Chain[T]": ...
     @t.overload
     def reduce_(
-        self: "Chain[t.Iterable]", iteratee: t.Callable[[T], T], accumulator: None = None
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Callable[[T], T], accumulator: None = None
     ) -> "Chain[T]": ...
     @t.overload
     def reduce_(
@@ -1261,7 +1265,7 @@ class AllFuncs:
     ) -> "Chain[T3]": ...
     @t.overload
     def reduce_right(
-        self: "Chain[t.Mapping]", iteratee: t.Callable[[T3], T3], accumulator: T3
+        self: "Chain[t.Mapping[t.Any, t.Any]]", iteratee: t.Callable[[T3], T3], accumulator: T3
     ) -> "Chain[T3]": ...
     @t.overload
     def reduce_right(
@@ -1277,7 +1281,9 @@ class AllFuncs:
     ) -> "Chain[T2]": ...
     @t.overload
     def reduce_right(
-        self: "Chain[t.Mapping]", iteratee: t.Callable[[T], T], accumulator: None = None
+        self: "Chain[t.Mapping[t.Any, t.Any]]",
+        iteratee: t.Callable[[T], T],
+        accumulator: None = None,
     ) -> "Chain[T]": ...
     @t.overload
     def reduce_right(
@@ -1289,7 +1295,7 @@ class AllFuncs:
     ) -> "Chain[T2]": ...
     @t.overload
     def reduce_right(
-        self: "Chain[t.Iterable]", iteratee: t.Callable[[T2], T2], accumulator: T2
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Callable[[T2], T2], accumulator: T2
     ) -> "Chain[T2]": ...
     @t.overload
     def reduce_right(
@@ -1301,7 +1307,7 @@ class AllFuncs:
     ) -> "Chain[T]": ...
     @t.overload
     def reduce_right(
-        self: "Chain[t.Iterable]", iteratee: t.Callable[[T], T], accumulator: None = None
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Callable[[T], T], accumulator: None = None
     ) -> "Chain[T]": ...
     @t.overload
     def reduce_right(
@@ -1326,7 +1332,7 @@ class AllFuncs:
     ) -> "Chain[t.List[T3]]": ...
     @t.overload
     def reductions(
-        self: "Chain[t.Mapping]",
+        self: "Chain[t.Mapping[t.Any, t.Any]]",
         iteratee: t.Callable[[T3], T3],
         accumulator: T3,
         from_right: bool = False,
@@ -1347,7 +1353,7 @@ class AllFuncs:
     ) -> "Chain[t.List[T2]]": ...
     @t.overload
     def reductions(
-        self: "Chain[t.Mapping]",
+        self: "Chain[t.Mapping[t.Any, t.Any]]",
         iteratee: t.Callable[[T], T],
         accumulator: None = None,
         from_right: bool = False,
@@ -1368,7 +1374,7 @@ class AllFuncs:
     ) -> "Chain[t.List[T2]]": ...
     @t.overload
     def reductions(
-        self: "Chain[t.Iterable]",
+        self: "Chain[t.Iterable[t.Any]]",
         iteratee: t.Callable[[T2], T2],
         accumulator: T2,
         from_right: bool = False,
@@ -1389,7 +1395,7 @@ class AllFuncs:
     ) -> "Chain[t.List[T]]": ...
     @t.overload
     def reductions(
-        self: "Chain[t.Iterable]",
+        self: "Chain[t.Iterable[t.Any]]",
         iteratee: t.Callable[[T], T],
         accumulator: None = None,
         from_right: bool = False,
@@ -1414,7 +1420,7 @@ class AllFuncs:
     ) -> "Chain[t.List[T3]]": ...
     @t.overload
     def reductions_right(
-        self: "Chain[t.Mapping]", iteratee: t.Callable[[T3], T3], accumulator: T3
+        self: "Chain[t.Mapping[t.Any, t.Any]]", iteratee: t.Callable[[T3], T3], accumulator: T3
     ) -> "Chain[t.List[T3]]": ...
     @t.overload
     def reductions_right(
@@ -1430,7 +1436,9 @@ class AllFuncs:
     ) -> "Chain[t.List[T2]]": ...
     @t.overload
     def reductions_right(
-        self: "Chain[t.Mapping]", iteratee: t.Callable[[T], T], accumulator: None = None
+        self: "Chain[t.Mapping[t.Any, t.Any]]",
+        iteratee: t.Callable[[T], T],
+        accumulator: None = None,
     ) -> "Chain[t.List[T]]": ...
     @t.overload
     def reductions_right(
@@ -1442,7 +1450,7 @@ class AllFuncs:
     ) -> "Chain[t.List[T2]]": ...
     @t.overload
     def reductions_right(
-        self: "Chain[t.Iterable]", iteratee: t.Callable[[T2], T2], accumulator: T2
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Callable[[T2], T2], accumulator: T2
     ) -> "Chain[t.List[T2]]": ...
     @t.overload
     def reductions_right(
@@ -1454,7 +1462,7 @@ class AllFuncs:
     ) -> "Chain[t.List[T]]": ...
     @t.overload
     def reductions_right(
-        self: "Chain[t.Iterable]", iteratee: t.Callable[[T], T], accumulator: None = None
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Callable[[T], T], accumulator: None = None
     ) -> "Chain[t.List[T]]": ...
     @t.overload
     def reductions_right(
@@ -1625,7 +1633,7 @@ class AllFuncs:
     def flip(self: "Chain[t.Callable[[T1, T2], T]]") -> "Chain[t.Callable[[T2, T1], T]]": ...
     @t.overload
     def flip(self: "Chain[t.Callable[[T1], T]]") -> "Chain[t.Callable[[T1], T]]": ...
-    def flip(self: "Chain[t.Callable]") -> "Chain[t.Callable]":
+    def flip(self: "Chain[t.Callable[..., t.Any]]") -> "Chain[t.Callable[..., t.Any]]":
         return self._wrap(pyd.flip)()
 
     @t.overload
@@ -1732,7 +1740,7 @@ class AllFuncs:
     def over_args(
         self: "Chain[t.Callable[[T1], T]]", transform_one: t.Callable[[T1], T1]
     ) -> "Chain[t.Callable[[T1], T]]": ...
-    def over_args(self: "Chain[t.Callable]", *transforms: t.Callable) -> "Chain[t.Callable]":
+    def over_args(self, *transforms):
         return self._wrap(pyd.over_args)(*transforms)
 
     def partial(
@@ -2193,7 +2201,7 @@ class AllFuncs:
     def assign(
         self: "Chain[t.Union[t.Tuple[T, ...], t.List[T]]]", *sources: t.Mapping[int, T2]
     ) -> "Chain[t.List[t.Union[T, T2]]]": ...
-    def assign(self, *sources) -> "Chain[t.Union[t.List, t.Dict]]":
+    def assign(self, *sources) -> "Chain[t.Union[t.List[t.Any], t.Dict[t.Any, t.Any]]]":
         return self._wrap(pyd.assign)(*sources)
 
     @t.overload
@@ -2239,7 +2247,7 @@ class AllFuncs:
     ) -> "Chain[t.List['SupportsRichComparisonT']]": ...
     @t.overload
     def callables(self: "Chain[t.Iterable[T]]") -> "Chain[t.List[T]]": ...
-    def callables(self) -> "Chain[t.List]":
+    def callables(self):
         return self._wrap(pyd.callables)()
 
     def clone(self: "Chain[T]") -> "Chain[T]":
@@ -2272,7 +2280,7 @@ class AllFuncs:
     @t.overload
     def clone_with(self: "Chain[T]", customizer: None = None) -> "Chain[T]": ...
     @t.overload
-    def clone_with(self: "Chain[t.Any]", customizer: t.Callable) -> "Chain[t.Any]": ...
+    def clone_with(self: "Chain[t.Any]", customizer: t.Callable[..., t.Any]) -> "Chain[t.Any]": ...
     def clone_with(self, customizer=None):
         return self._wrap(pyd.clone_with)(customizer)
 
@@ -2306,7 +2314,9 @@ class AllFuncs:
     @t.overload
     def clone_deep_with(self: "Chain[T]", customizer: None = None) -> "Chain[T]": ...
     @t.overload
-    def clone_deep_with(self: "Chain[t.Any]", customizer: t.Callable) -> "Chain[t.Any]": ...
+    def clone_deep_with(
+        self: "Chain[t.Any]", customizer: t.Callable[..., t.Any]
+    ) -> "Chain[t.Any]": ...
     def clone_deep_with(self, customizer=None):
         return self._wrap(pyd.clone_deep_with)(customizer)
 
@@ -2502,7 +2512,7 @@ class AllFuncs:
     @t.overload
     def keys(self: "Chain[t.Iterable[T]]") -> "Chain[t.List[T]]": ...
     @t.overload
-    def keys(self: "Chain[t.Any]") -> "Chain[t.List]": ...
+    def keys(self: "Chain[t.Any]") -> "Chain[t.List[t.Any]]": ...
     def keys(self):
         return self._wrap(pyd.keys)()
 
@@ -2532,8 +2542,8 @@ class AllFuncs:
     ) -> "Chain[t.Dict[T2, T]]": ...
     @t.overload
     def map_keys(
-        self: "Chain[t.Iterable]", iteratee: t.Union[IterateeObjT, None] = None
-    ) -> "Chain[t.Dict]": ...
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Union[IterateeObjT, None] = None
+    ) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     def map_keys(self, iteratee=None):
         return self._wrap(pyd.map_keys)(iteratee)
 
@@ -2563,14 +2573,14 @@ class AllFuncs:
     ) -> "Chain[t.Dict[T, T2]]": ...
     @t.overload
     def map_values(
-        self: "Chain[t.Iterable]", iteratee: t.Union[IterateeObjT, None] = None
-    ) -> "Chain[t.Dict]": ...
+        self: "Chain[t.Iterable[t.Any]]", iteratee: t.Union[IterateeObjT, None] = None
+    ) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     def map_values(self, iteratee=None):
         return self._wrap(pyd.map_values)(iteratee)
 
     def map_values_deep(
-        self: "Chain[t.Iterable]",
-        iteratee: t.Union[t.Callable, None] = None,
+        self: "Chain[t.Iterable[t.Any]]",
+        iteratee: t.Union[t.Callable[..., t.Any], None] = None,
         property_path: t.Any = UNSET,
     ) -> "Chain[t.Any]":
         return self._wrap(pyd.map_values_deep)(iteratee, property_path)
@@ -2626,7 +2636,7 @@ class AllFuncs:
         self: "Chain[t.Union[t.Iterator[T], t.Sequence[T]]]", *properties: PathT
     ) -> "Chain[t.Dict[int, T]]": ...
     @t.overload
-    def omit(self: "Chain[t.Any]", *properties: PathT) -> "Chain[t.Dict]": ...
+    def omit(self: "Chain[t.Any]", *properties: PathT) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     def omit(self, *properties):
         return self._wrap(pyd.omit)(*properties)
 
@@ -2652,8 +2662,8 @@ class AllFuncs:
     def omit_by(self: "Chain[t.List[T]]", iteratee: None = None) -> "Chain[t.Dict[int, T]]": ...
     @t.overload
     def omit_by(
-        self: "Chain[t.Any]", iteratee: t.Union[t.Callable, None] = None
-    ) -> "Chain[t.Dict]": ...
+        self: "Chain[t.Any]", iteratee: t.Union[t.Callable[..., t.Any], None] = None
+    ) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     def omit_by(self, iteratee=None):
         return self._wrap(pyd.omit_by)(iteratee)
 
@@ -2669,7 +2679,7 @@ class AllFuncs:
         self: "Chain[t.Union[t.Tuple[T, ...], t.List[T]]]", *properties: PathT
     ) -> "Chain[t.Dict[int, T]]": ...
     @t.overload
-    def pick(self: "Chain[t.Any]", *properties: PathT) -> "Chain[t.Dict]": ...
+    def pick(self: "Chain[t.Any]", *properties: PathT) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     def pick(self, *properties):
         return self._wrap(pyd.pick)(*properties)
 
@@ -2697,8 +2707,8 @@ class AllFuncs:
     ) -> "Chain[t.Dict[int, T]]": ...
     @t.overload
     def pick_by(
-        self: "Chain[t.Any]", iteratee: t.Union[t.Callable, None] = None
-    ) -> "Chain[t.Dict]": ...
+        self: "Chain[t.Any]", iteratee: t.Union[t.Callable[..., t.Any], None] = None
+    ) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     def pick_by(self, iteratee=None):
         return self._wrap(pyd.pick_by)(iteratee)
 
@@ -2713,7 +2723,10 @@ class AllFuncs:
     set = set_
 
     def set_with(
-        self: "Chain[T]", path: PathT, value: t.Any, customizer: t.Union[t.Callable, None] = None
+        self: "Chain[T]",
+        path: PathT,
+        value: t.Any,
+        customizer: t.Union[t.Callable[..., t.Any], None] = None,
     ) -> "Chain[T]":
         return self._wrap(pyd.set_with)(path, value, customizer)
 
@@ -2731,7 +2744,7 @@ class AllFuncs:
         self: "Chain[t.Union[t.Iterator[T], t.Sequence[T]]]",
     ) -> "Chain[t.Dict[int, T]]": ...
     @t.overload
-    def to_dict(self: "Chain[t.Any]") -> "Chain[t.Dict]": ...
+    def to_dict(self: "Chain[t.Any]") -> "Chain[t.Dict[t.Any, t.Any]]": ...
     def to_dict(self):
         return self._wrap(pyd.to_dict)()
 
@@ -2759,7 +2772,7 @@ class AllFuncs:
         self: "Chain[t.Union[t.Iterator[T], t.Sequence[T]]]",
     ) -> "Chain[t.List[t.Tuple[int, T]]]": ...
     @t.overload
-    def to_pairs(self: "Chain[t.Any]") -> "Chain[t.List]": ...
+    def to_pairs(self: "Chain[t.Any]") -> "Chain[t.List[t.Any]]": ...
     def to_pairs(self):
         return self._wrap(pyd.to_pairs)()
 
@@ -2809,13 +2822,13 @@ class AllFuncs:
     @t.overload
     def update(
         self: "Chain[t.Dict[t.Any, T2]]", path: PathT, updater: t.Callable[[T2], t.Any]
-    ) -> "Chain[t.Dict]": ...
+    ) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     @t.overload
     def update(
         self: "Chain[t.List[T]]", path: PathT, updater: t.Callable[[T], t.Any]
-    ) -> "Chain[t.List]": ...
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
-    def update(self: "Chain[T]", path: PathT, updater: t.Callable) -> "Chain[T]": ...
+    def update(self: "Chain[T]", path: PathT, updater: t.Callable[..., t.Any]) -> "Chain[T]": ...
     def update(self, path, updater):
         return self._wrap(pyd.update)(path, updater)
 
@@ -2824,26 +2837,28 @@ class AllFuncs:
         self: "Chain[t.Dict[t.Any, T2]]",
         path: PathT,
         updater: t.Callable[[T2], t.Any],
-        customizer: t.Union[t.Callable, None],
-    ) -> "Chain[t.Dict]": ...
+        customizer: t.Union[t.Callable[..., t.Any], None],
+    ) -> "Chain[t.Dict[t.Any, t.Any]]": ...
     @t.overload
     def update_with(
         self: "Chain[t.List[T]]",
         path: PathT,
         updater: t.Callable[[T], t.Any],
-        customizer: t.Union[t.Callable, None] = None,
-    ) -> "Chain[t.List]": ...
+        customizer: t.Union[t.Callable[..., t.Any], None] = None,
+    ) -> "Chain[t.List[t.Any]]": ...
     @t.overload
     def update_with(
         self: "Chain[T]",
         path: PathT,
-        updater: t.Callable,
-        customizer: t.Union[t.Callable, None] = None,
+        updater: t.Callable[..., t.Any],
+        customizer: t.Union[t.Callable[..., t.Any], None] = None,
     ) -> "Chain[T]": ...
     def update_with(self, path, updater, customizer=None):
         return self._wrap(pyd.update_with)(path, updater, customizer)
 
-    def unset(self: "Chain[t.Union[t.List, t.Dict]]", path: PathT) -> "Chain[bool]":
+    def unset(
+        self: "Chain[t.Union[t.List[t.Any], t.Dict[t.Any, t.Any]]]", path: PathT
+    ) -> "Chain[bool]":
         return self._wrap(pyd.unset)(path)
 
     @t.overload
@@ -2851,7 +2866,7 @@ class AllFuncs:
     @t.overload
     def values(self: "Chain[t.Iterable[T]]") -> "Chain[t.List[T]]": ...
     @t.overload
-    def values(self: "Chain[t.Any]") -> "Chain[t.List]": ...
+    def values(self: "Chain[t.Any]") -> "Chain[t.List[t.Any]]": ...
     def values(self):
         return self._wrap(pyd.values)()
 
@@ -2929,7 +2944,7 @@ class AllFuncs:
     ) -> "Chain[T3]": ...
     @t.overload
     def is_equal_with(
-        self: "Chain[t.Any]", other: t.Any, customizer: t.Callable
+        self: "Chain[t.Any]", other: t.Any, customizer: t.Callable[..., t.Any]
     ) -> "Chain[bool]": ...
     @t.overload
     def is_equal_with(self: "Chain[t.Any]", other: t.Any, customizer: None) -> "Chain[bool]": ...
@@ -3161,14 +3176,14 @@ class AllFuncs:
         return self._wrap(pyd.reg_exp_js_match)(reg_exp)
 
     def reg_exp_js_replace(
-        self: "Chain[t.Any]", reg_exp: str, repl: t.Union[str, t.Callable[[re.Match], str]]
+        self: "Chain[t.Any]", reg_exp: str, repl: t.Union[str, t.Callable[[re.Match[str]], str]]
     ) -> "Chain[str]":
         return self._wrap(pyd.reg_exp_js_replace)(reg_exp, repl)
 
     def reg_exp_replace(
         self: "Chain[t.Any]",
         pattern: t.Any,
-        repl: t.Union[str, t.Callable[[re.Match], str]],
+        repl: t.Union[str, t.Callable[[re.Match[str]], str]],
         ignore_case: bool = False,
         count: int = 0,
     ) -> "Chain[str]":
@@ -3180,7 +3195,7 @@ class AllFuncs:
     def replace(
         self: "Chain[t.Any]",
         pattern: t.Any,
-        repl: t.Union[str, t.Callable[[re.Match], str]],
+        repl: t.Union[str, t.Callable[[re.Match[str]], str]],
         ignore_case: bool = False,
         count: int = 0,
         escape: bool = True,
@@ -3194,7 +3209,7 @@ class AllFuncs:
     def replace_end(
         self: "Chain[t.Any]",
         pattern: t.Any,
-        repl: t.Union[str, t.Callable[[re.Match], str]],
+        repl: t.Union[str, t.Callable[[re.Match[str]], str]],
         ignore_case: bool = False,
         escape: bool = True,
     ) -> "Chain[str]":
@@ -3203,7 +3218,7 @@ class AllFuncs:
     def replace_start(
         self: "Chain[t.Any]",
         pattern: t.Any,
-        repl: t.Union[str, t.Callable[[re.Match], str]],
+        repl: t.Union[str, t.Callable[[re.Match[str]], str]],
         ignore_case: bool = False,
         escape: bool = True,
     ) -> "Chain[str]":
@@ -3288,7 +3303,7 @@ class AllFuncs:
         self: "Chain[t.Any]",
         length: int = 30,
         omission: str = "...",
-        separator: t.Union[str, re.Pattern, None] = None,
+        separator: t.Union[str, re.Pattern[str], None] = None,
     ) -> "Chain[str]":
         return self._wrap(pyd.truncate)(length, omission, separator)
 
@@ -3336,7 +3351,9 @@ class AllFuncs:
     def conforms(
         self: "Chain[t.List[t.Callable[[T], t.Any]]]",
     ) -> "Chain[t.Callable[[t.List[T]], bool]]": ...
-    def conforms(self: "Chain[t.Union[t.List, t.Dict]]") -> "Chain[t.Callable]":
+    def conforms(
+        self: "Chain[t.Union[t.List[t.Any], t.Dict[t.Any, t.Any]]]",
+    ) -> "Chain[t.Callable[..., t.Any]]":
         return self._wrap(pyd.conforms)()
 
     @t.overload
@@ -3398,7 +3415,7 @@ class AllFuncs:
     @t.overload
     def iteratee(self: "Chain[t.Callable[P, T]]") -> "Chain[t.Callable[P, T]]": ...
     @t.overload
-    def iteratee(self: "Chain[t.Any]") -> "Chain[t.Callable]": ...
+    def iteratee(self: "Chain[t.Any]") -> "Chain[t.Callable[..., t.Any]]": ...
     def iteratee(self):
         return self._wrap(pyd.iteratee)()
 

--- a/src/pydash/chaining/chaining.py
+++ b/src/pydash/chaining/chaining.py
@@ -33,7 +33,7 @@ class Chain(AllFuncs, t.Generic[ValueT_co]):
     def __init__(self, value: t.Union[ValueT_co, Unset] = UNSET) -> None:
         self._value = value
 
-    def _wrap(self, func) -> "ChainWrapper":
+    def _wrap(self, func) -> "ChainWrapper[t.Union[ValueT_co, Unset]]":
         """Implement `AllFuncs` interface."""
         return ChainWrapper(self._value, func)
 
@@ -116,7 +116,7 @@ class ChainWrapper(t.Generic[ValueT_co]):
         self._value = value
         self.method = method
         self.args = ()
-        self.kwargs: t.Dict = {}
+        self.kwargs: t.Dict[t.Any, t.Any] = {}
 
     def _generate(self):
         """Generate a copy of this instance."""

--- a/src/pydash/collections.py
+++ b/src/pydash/collections.py
@@ -538,41 +538,41 @@ def flat_map(collection, iteratee=None):
 def flat_map_deep(
     collection: t.Mapping[T, T2],
     iteratee: t.Union[t.Callable[[T2, T, t.Dict[T, T2]], t.Any], None] = None,
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
 def flat_map_deep(
     collection: t.Mapping[T, T2], iteratee: t.Union[t.Callable[[T2, T], t.Any], None] = None
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
 def flat_map_deep(
     collection: t.Mapping[t.Any, T2], iteratee: t.Union[t.Callable[[T2], t.Any], None] = None
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
 def flat_map_deep(
     collection: t.Iterable[T],
     iteratee: t.Union[t.Callable[[T, int, t.List[T]], t.Any], None] = None,
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
 def flat_map_deep(
     collection: t.Iterable[T], iteratee: t.Union[t.Callable[[T, int], t.Any], None] = None
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
 def flat_map_deep(
     collection: t.Iterable[T], iteratee: t.Union[t.Callable[[T], t.Any], None] = None
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
-def flat_map_deep(collection: t.Iterable, iteratee=None):
+def flat_map_deep(collection, iteratee=None):
     """
     This method is like :func:`flat_map` except that it recursively flattens the mapped results.
 
@@ -599,7 +599,7 @@ def flat_map_depth(
     collection: t.Mapping[T, T2],
     iteratee: t.Union[t.Callable[[T2, T, t.Dict[T, T2]], t.Any], None] = None,
     depth: int = 1,
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
@@ -607,7 +607,7 @@ def flat_map_depth(
     collection: t.Mapping[T, T2],
     iteratee: t.Union[t.Callable[[T2, T], t.Any], None] = None,
     depth: int = 1,
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
@@ -615,7 +615,7 @@ def flat_map_depth(
     collection: t.Mapping[t.Any, T2],
     iteratee: t.Union[t.Callable[[T2], t.Any], None] = None,
     depth: int = 1,
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
@@ -623,7 +623,7 @@ def flat_map_depth(
     collection: t.Iterable[T],
     iteratee: t.Union[t.Callable[[T, int, t.List[T]], t.Any], None] = None,
     depth: int = 1,
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
@@ -631,7 +631,7 @@ def flat_map_depth(
     collection: t.Iterable[T],
     iteratee: t.Union[t.Callable[[T, int], t.Any], None] = None,
     depth: int = 1,
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
@@ -639,7 +639,7 @@ def flat_map_depth(
     collection: t.Iterable[T],
     iteratee: t.Union[t.Callable[[T], t.Any], None] = None,
     depth: int = 1,
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 def flat_map_depth(collection, iteratee=None, depth=1):
@@ -856,7 +856,9 @@ def group_by(collection, iteratee=None):
     return ret
 
 
-def includes(collection: t.Union[t.Sequence, t.Dict], target: t.Any, from_index: int = 0) -> bool:
+def includes(
+    collection: t.Union[t.Sequence[t.Any], t.Dict[t.Any, t.Any]], target: t.Any, from_index: int = 0
+) -> bool:
     """
     Checks if a given value is present in a collection. If `from_index` is negative, it is used as
     the offset from the end of the collection.
@@ -884,7 +886,7 @@ def includes(collection: t.Union[t.Sequence, t.Dict], target: t.Any, from_index:
         Renamed from ``contains`` to ``includes`` and removed alias
         ``include``.
     """
-    collection_values: t.Container
+    collection_values: t.Container[t.Any]
     if isinstance(collection, dict):
         collection_values = collection.values()
     else:
@@ -894,7 +896,9 @@ def includes(collection: t.Union[t.Sequence, t.Dict], target: t.Any, from_index:
     return target in collection_values
 
 
-def invoke_map(collection: t.Iterable, path: PathT, *args: t.Any, **kwargs: t.Any) -> t.List[t.Any]:
+def invoke_map(
+    collection: t.Iterable[t.Any], path: PathT, *args: t.Any, **kwargs: t.Any
+) -> t.List[t.Any]:
     """
     Invokes the method at `path` of each element in `collection`, returning a list of the results of
     each invoked method. Any additional arguments are provided to each invoked method. If `path` is
@@ -927,7 +931,9 @@ def key_by(collection: t.Iterable[T], iteratee: t.Callable[[T], T2]) -> t.Dict[T
 
 
 @t.overload
-def key_by(collection: t.Iterable, iteratee: t.Union[IterateeObjT, None] = None) -> t.Dict: ...
+def key_by(
+    collection: t.Iterable[t.Any], iteratee: t.Union[IterateeObjT, None] = None
+) -> t.Dict[t.Any, t.Any]: ...
 
 
 def key_by(collection, iteratee=None):
@@ -1033,7 +1039,7 @@ def map_(collection, iteratee=None):
     return list(itermap(collection, iteratee))
 
 
-def nest(collection: t.Iterable, *properties: t.Any) -> t.Any:
+def nest(collection: t.Iterable[t.Any], *properties: t.Any) -> t.Any:
     """
     This method is like :func:`group_by` except that it supports nested grouping by multiple string
     `properties`. If only a single key is given, it is like calling ``group_by(collection, prop)``.
@@ -1288,7 +1294,7 @@ def partition(collection, predicate=None):
     return [trues, falses]
 
 
-def pluck(collection: t.Iterable, path: PathT) -> t.List:
+def pluck(collection: t.Iterable[t.Any], path: PathT) -> t.List[t.Any]:
     """
     Retrieves the value of a specified property from all elements in the collection.
 
@@ -1341,7 +1347,7 @@ def reduce_(
 
 @t.overload
 def reduce_(
-    collection: t.Mapping,
+    collection: t.Mapping[t.Any, t.Any],
     iteratee: t.Callable[[T3], T3],
     accumulator: T3,
 ) -> T3: ...
@@ -1365,7 +1371,7 @@ def reduce_(
 
 @t.overload
 def reduce_(
-    collection: t.Mapping,
+    collection: t.Mapping[t.Any, t.Any],
     iteratee: t.Callable[[T], T],
     accumulator: None = None,
 ) -> T: ...
@@ -1389,7 +1395,7 @@ def reduce_(
 
 @t.overload
 def reduce_(
-    collection: t.Iterable,
+    collection: t.Iterable[t.Any],
     iteratee: t.Callable[[T2], T2],
     accumulator: T2,
 ) -> T2: ...
@@ -1413,7 +1419,7 @@ def reduce_(
 
 @t.overload
 def reduce_(
-    collection: t.Iterable,
+    collection: t.Iterable[t.Any],
     iteratee: t.Callable[[T], T],
     accumulator: None = None,
 ) -> T: ...
@@ -1490,7 +1496,7 @@ def reduce_right(
 
 @t.overload
 def reduce_right(
-    collection: t.Mapping,
+    collection: t.Mapping[t.Any, t.Any],
     iteratee: t.Callable[[T3], T3],
     accumulator: T3,
 ) -> T3: ...
@@ -1514,7 +1520,7 @@ def reduce_right(
 
 @t.overload
 def reduce_right(
-    collection: t.Mapping,
+    collection: t.Mapping[t.Any, t.Any],
     iteratee: t.Callable[[T], T],
     accumulator: None = None,
 ) -> T: ...
@@ -1538,7 +1544,7 @@ def reduce_right(
 
 @t.overload
 def reduce_right(
-    collection: t.Iterable,
+    collection: t.Iterable[t.Any],
     iteratee: t.Callable[[T2], T2],
     accumulator: T2,
 ) -> T2: ...
@@ -1562,7 +1568,7 @@ def reduce_right(
 
 @t.overload
 def reduce_right(
-    collection: t.Iterable,
+    collection: t.Iterable[t.Any],
     iteratee: t.Callable[[T], T],
     accumulator: None = None,
 ) -> T: ...
@@ -1627,7 +1633,7 @@ def reductions(
 
 @t.overload
 def reductions(
-    collection: t.Mapping,
+    collection: t.Mapping[t.Any, t.Any],
     iteratee: t.Callable[[T3], T3],
     accumulator: T3,
     from_right: bool = False,
@@ -1654,7 +1660,7 @@ def reductions(
 
 @t.overload
 def reductions(
-    collection: t.Mapping,
+    collection: t.Mapping[t.Any, t.Any],
     iteratee: t.Callable[[T], T],
     accumulator: None = None,
     from_right: bool = False,
@@ -1681,7 +1687,7 @@ def reductions(
 
 @t.overload
 def reductions(
-    collection: t.Iterable,
+    collection: t.Iterable[t.Any],
     iteratee: t.Callable[[T2], T2],
     accumulator: T2,
     from_right: bool = False,
@@ -1708,7 +1714,7 @@ def reductions(
 
 @t.overload
 def reductions(
-    collection: t.Iterable,
+    collection: t.Iterable[t.Any],
     iteratee: t.Callable[[T], T],
     accumulator: None = None,
     from_right: bool = False,
@@ -1786,7 +1792,7 @@ def reductions_right(
 
 @t.overload
 def reductions_right(
-    collection: t.Mapping,
+    collection: t.Mapping[t.Any, t.Any],
     iteratee: t.Callable[[T3], T3],
     accumulator: T3,
 ) -> t.List[T3]: ...
@@ -1810,7 +1816,7 @@ def reductions_right(
 
 @t.overload
 def reductions_right(
-    collection: t.Mapping,
+    collection: t.Mapping[t.Any, t.Any],
     iteratee: t.Callable[[T], T],
     accumulator: None = None,
 ) -> t.List[T]: ...
@@ -1834,7 +1840,7 @@ def reductions_right(
 
 @t.overload
 def reductions_right(
-    collection: t.Iterable,
+    collection: t.Iterable[t.Any],
     iteratee: t.Callable[[T2], T2],
     accumulator: T2,
 ) -> t.List[T2]: ...
@@ -1858,7 +1864,7 @@ def reductions_right(
 
 @t.overload
 def reductions_right(
-    collection: t.Iterable,
+    collection: t.Iterable[t.Any],
     iteratee: t.Callable[[T], T],
     accumulator: None = None,
 ) -> t.List[T]: ...
@@ -2167,9 +2173,9 @@ def sort_by(collection, iteratee=None, reverse=False):
 
 
 def itermap(
-    collection: t.Iterable,
-    iteratee: t.Union[t.Callable, IterateeObjT, None] = None,
-) -> t.Generator:
+    collection: t.Iterable[t.Any],
+    iteratee: t.Union[t.Callable[..., t.Any], IterateeObjT, None] = None,
+) -> t.Generator[t.Any, None, None]:
     """Generative mapper."""
     for result in iteriteratee(collection, iteratee):
         yield result[0]

--- a/src/pydash/functions.py
+++ b/src/pydash/functions.py
@@ -55,7 +55,7 @@ P = ParamSpec("P")
 
 
 class _WithArgCount(Protocol):
-    func: t.Callable
+    func: t.Callable[..., t.Any]
 
     @cached_property
     def _argcount(self) -> t.Optional[int]:
@@ -110,7 +110,7 @@ class Ary(_WithArgCount, t.Generic[T]):
         return self.func(*cut_args, **kwargs)  # type: ignore
 
 
-class Before(After, t.Generic[P, T]):
+class Before(After[P, T], t.Generic[P, T]):
     """Wrap a function in a before context."""
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> t.Union[T, None]:
@@ -447,7 +447,7 @@ class Disjoin(t.Generic[T]):
 class Flip(_WithArgCount):
     """Wrap a function in a flip context."""
 
-    def __init__(self, func: t.Callable) -> None:
+    def __init__(self, func: t.Callable[..., t.Any]) -> None:
         self.func = func
 
     def __call__(self, *args, **kwargs):
@@ -495,7 +495,7 @@ class Juxtapose(t.Generic[P, T]):
 class OverArgs(_WithArgCount):
     """Wrap a function in an over_args context."""
 
-    def __init__(self, func: t.Callable, *transforms: t.Callable) -> None:
+    def __init__(self, func: t.Callable[..., t.Any], *transforms: t.Callable[..., t.Any]) -> None:
         self.func = func
         self.transforms = pyd.flatten(transforms)
 
@@ -608,7 +608,7 @@ class Spread(t.Generic[T]):
     def __init__(self, func: t.Callable[..., T]) -> None:
         self.func = func
 
-    def __call__(self, args: t.Iterable) -> T:
+    def __call__(self, args: t.Iterable[t.Any]) -> T:
         """Return results from :attr:`func` using array of `args` provided."""
         return self.func(*args)
 
@@ -962,7 +962,7 @@ def flip(func: t.Callable[[T1, T2], T]) -> t.Callable[[T2, T1], T]: ...
 def flip(func: t.Callable[[T1], T]) -> t.Callable[[T1], T]: ...
 
 
-def flip(func: t.Callable) -> t.Callable:
+def flip(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
     """
     Creates a function that invokes the method with arguments reversed.
 
@@ -1267,7 +1267,7 @@ def over_args(
 ) -> t.Callable[[T1], T]: ...
 
 
-def over_args(func: t.Callable, *transforms: t.Callable) -> t.Callable:  # type: ignore
+def over_args(func, *transforms):
     """
     Creates a function that runs each argument through a corresponding transform function.
 

--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -92,7 +92,7 @@ def assign(
 ) -> t.List[t.Union[T, T2]]: ...
 
 
-def assign(obj, *sources) -> t.Union[t.List, t.Dict]:
+def assign(obj, *sources) -> t.Union[t.List[t.Any], t.Dict[t.Any, t.Any]]:
     """
     Assigns properties of source object(s) to the destination object.
 
@@ -243,7 +243,7 @@ def callables(
 def callables(obj: t.Iterable[T]) -> t.List[T]: ...
 
 
-def callables(obj) -> t.List:
+def callables(obj):
     """
     Creates a sorted list of keys of an object that are callable.
 
@@ -337,7 +337,7 @@ def clone_with(value: T, customizer: None = None) -> T: ...
 
 
 @t.overload
-def clone_with(value: t.Any, customizer: t.Callable) -> t.Any: ...
+def clone_with(value: t.Any, customizer: t.Callable[..., t.Any]) -> t.Any: ...
 
 
 def clone_with(value, customizer=None):
@@ -435,7 +435,7 @@ def clone_deep_with(value: T, customizer: None = None) -> T: ...
 
 
 @t.overload
-def clone_deep_with(value: t.Any, customizer: t.Callable) -> t.Any: ...
+def clone_deep_with(value: t.Any, customizer: t.Callable[..., t.Any]) -> t.Any: ...
 
 
 def clone_deep_with(value, customizer=None):
@@ -1065,7 +1065,7 @@ def keys(obj: t.Iterable[T]) -> t.List[T]: ...
 
 
 @t.overload
-def keys(obj: t.Any) -> t.List: ...
+def keys(obj: t.Any) -> t.List[t.Any]: ...
 
 
 def keys(obj):
@@ -1125,7 +1125,9 @@ def map_keys(obj: t.Iterable[T], iteratee: t.Callable[[T], T2]) -> t.Dict[T2, T]
 
 
 @t.overload
-def map_keys(obj: t.Iterable, iteratee: t.Union[IterateeObjT, None] = None) -> t.Dict: ...
+def map_keys(
+    obj: t.Iterable[t.Any], iteratee: t.Union[IterateeObjT, None] = None
+) -> t.Dict[t.Any, t.Any]: ...
 
 
 def map_keys(obj, iteratee=None):
@@ -1182,7 +1184,9 @@ def map_values(obj: t.Iterable[T], iteratee: t.Callable[[T], T2]) -> t.Dict[T, T
 
 
 @t.overload
-def map_values(obj: t.Iterable, iteratee: t.Union[IterateeObjT, None] = None) -> t.Dict: ...
+def map_values(
+    obj: t.Iterable[t.Any], iteratee: t.Union[IterateeObjT, None] = None
+) -> t.Dict[t.Any, t.Any]: ...
 
 
 def map_values(obj, iteratee=None):
@@ -1213,7 +1217,9 @@ def map_values(obj, iteratee=None):
 
 
 def map_values_deep(
-    obj: t.Iterable, iteratee: t.Union[t.Callable, None] = None, property_path: t.Any = UNSET
+    obj: t.Iterable[t.Any],
+    iteratee: t.Union[t.Callable[..., t.Any], None] = None,
+    property_path: t.Any = UNSET,
 ) -> t.Any:
     """
     Map all non-object values in `obj` with return values from `iteratee`. The iteratee is invoked
@@ -1520,7 +1526,7 @@ def omit(obj: t.Union[t.Iterator[T], t.Sequence[T]], *properties: PathT) -> t.Di
 
 
 @t.overload
-def omit(obj: t.Any, *properties: PathT) -> t.Dict: ...
+def omit(obj: t.Any, *properties: PathT) -> t.Dict[t.Any, t.Any]: ...
 
 
 def omit(obj, *properties):
@@ -1586,7 +1592,9 @@ def omit_by(obj: t.List[T], iteratee: None = None) -> t.Dict[int, T]: ...
 
 
 @t.overload
-def omit_by(obj: t.Any, iteratee: t.Union[t.Callable, None] = None) -> t.Dict: ...
+def omit_by(
+    obj: t.Any, iteratee: t.Union[t.Callable[..., t.Any], None] = None
+) -> t.Dict[t.Any, t.Any]: ...
 
 
 def omit_by(obj, iteratee=None):
@@ -1693,7 +1701,7 @@ def pick(obj: t.Union[t.Tuple[T, ...], t.List[T]], *properties: PathT) -> t.Dict
 
 
 @t.overload
-def pick(obj: t.Any, *properties: PathT) -> t.Dict: ...
+def pick(obj: t.Any, *properties: PathT) -> t.Dict[t.Any, t.Any]: ...
 
 
 def pick(obj, *properties):
@@ -1749,7 +1757,9 @@ def pick_by(obj: t.Union[t.Tuple[T, ...], t.List[T]], iteratee: None = None) -> 
 
 
 @t.overload
-def pick_by(obj: t.Any, iteratee: t.Union[t.Callable, None] = None) -> t.Dict: ...
+def pick_by(
+    obj: t.Any, iteratee: t.Union[t.Callable[..., t.Any], None] = None
+) -> t.Dict[t.Any, t.Any]: ...
 
 
 def pick_by(obj, iteratee=None):
@@ -1865,7 +1875,9 @@ def set_(obj: T, path: PathT, value: t.Any) -> T:
     return set_with(obj, path, value)
 
 
-def set_with(obj: T, path: PathT, value: t.Any, customizer: t.Union[t.Callable, None] = None) -> T:
+def set_with(
+    obj: T, path: PathT, value: t.Any, customizer: t.Union[t.Callable[..., t.Any], None] = None
+) -> T:
     """
     This method is like :func:`set_` except that it accepts customizer which is invoked to produce
     the objects of path. If customizer returns undefined path creation is handled by the method
@@ -1963,7 +1975,7 @@ def to_dict(obj: t.Union[t.Iterator[T], t.Sequence[T]]) -> t.Dict[int, T]: ...
 
 
 @t.overload
-def to_dict(obj: t.Any) -> t.Dict: ...
+def to_dict(obj: t.Any) -> t.Dict[t.Any, t.Any]: ...
 
 
 def to_dict(obj):
@@ -2134,7 +2146,7 @@ def to_number(obj: t.Any, precision: int = 0) -> t.Union[float, None]:
         if precision < 0:
             # Round down since negative `precision` means we are going to the nearest positive
             # integer place.
-            rounder: t.Callable = math.floor
+            rounder: t.Callable[..., t.Any] = math.floor
         else:
             rounder = round
 
@@ -2154,7 +2166,7 @@ def to_pairs(obj: t.Union[t.Iterator[T], t.Sequence[T]]) -> t.List[t.Tuple[int, 
 
 
 @t.overload
-def to_pairs(obj: t.Any) -> t.List: ...
+def to_pairs(obj: t.Any) -> t.List[t.Any]: ...
 
 
 def to_pairs(obj):
@@ -2316,7 +2328,7 @@ def update(
     obj: t.Dict[t.Any, T2],
     path: PathT,
     updater: t.Callable[[T2], t.Any],
-) -> t.Dict: ...
+) -> t.Dict[t.Any, t.Any]: ...
 
 
 @t.overload
@@ -2324,14 +2336,14 @@ def update(
     obj: t.List[T],
     path: PathT,
     updater: t.Callable[[T], t.Any],
-) -> t.List: ...
+) -> t.List[t.Any]: ...
 
 
 @t.overload
 def update(
     obj: T,
     path: PathT,
-    updater: t.Callable,
+    updater: t.Callable[..., t.Any],
 ) -> T: ...
 
 
@@ -2369,8 +2381,8 @@ def update_with(
     obj: t.Dict[t.Any, T2],
     path: PathT,
     updater: t.Callable[[T2], t.Any],
-    customizer: t.Union[t.Callable, None],
-) -> t.Dict: ...
+    customizer: t.Union[t.Callable[..., t.Any], None],
+) -> t.Dict[t.Any, t.Any]: ...
 
 
 @t.overload
@@ -2378,16 +2390,16 @@ def update_with(
     obj: t.List[T],
     path: PathT,
     updater: t.Callable[[T], t.Any],
-    customizer: t.Union[t.Callable, None] = None,
-) -> t.List: ...
+    customizer: t.Union[t.Callable[..., t.Any], None] = None,
+) -> t.List[t.Any]: ...
 
 
 @t.overload
 def update_with(
     obj: T,
     path: PathT,
-    updater: t.Callable,
-    customizer: t.Union[t.Callable, None] = None,
+    updater: t.Callable[..., t.Any],
+    customizer: t.Union[t.Callable[..., t.Any], None] = None,
 ) -> T: ...
 
 
@@ -2469,7 +2481,7 @@ def update_with(obj, path, updater, customizer=None):  # noqa: PLR0912
     return obj
 
 
-def unset(obj: t.Union[t.List, t.Dict], path: PathT) -> bool:  # noqa: C901
+def unset(obj: t.Union[t.List[t.Any], t.Dict[t.Any, t.Any]], path: PathT) -> bool:  # noqa: C901
     """
     Removes the property at `path` of `obj`.
 
@@ -2547,7 +2559,7 @@ def values(obj: t.Iterable[T]) -> t.List[T]: ...
 
 
 @t.overload
-def values(obj: t.Any) -> t.List: ...
+def values(obj: t.Any) -> t.List[t.Any]: ...
 
 
 def values(obj):

--- a/src/pydash/predicates.py
+++ b/src/pydash/predicates.py
@@ -708,7 +708,7 @@ def is_equal_with(value: T, other: T2, customizer: t.Callable[[T, T2], T3]) -> T
 
 
 @t.overload
-def is_equal_with(value: t.Any, other: t.Any, customizer: t.Callable) -> bool: ...
+def is_equal_with(value: t.Any, other: t.Any, customizer: t.Callable[..., t.Any]) -> bool: ...
 
 
 @t.overload
@@ -1501,7 +1501,7 @@ def is_positive(value: t.Any) -> bool:
     return is_number(value) and value > 0
 
 
-def is_reg_exp(value: t.Any) -> TypeGuard[re.Pattern]:
+def is_reg_exp(value: t.Any) -> TypeGuard[re.Pattern[t.Any]]:
     """
     Checks if `value` is a ``RegExp`` object.
 

--- a/src/pydash/strings.py
+++ b/src/pydash/strings.py
@@ -121,7 +121,7 @@ class JSRegExp:
                 results = []
         return results
 
-    def replace(self, text: str, repl: t.Union[str, t.Callable[[re.Match], str]]) -> str:
+    def replace(self, text: str, repl: t.Union[str, t.Callable[[re.Match[str]], str]]) -> str:
         """Replace parts of text that match the regular expression."""
         count = 0 if self._global else 1
         return self.pattern.sub(repl, text, count=count)
@@ -1187,7 +1187,7 @@ def reg_exp_js_match(text: t.Any, reg_exp: str) -> t.List[str]:
 
 
 def reg_exp_js_replace(
-    text: t.Any, reg_exp: str, repl: t.Union[str, t.Callable[[re.Match], str]]
+    text: t.Any, reg_exp: str, repl: t.Union[str, t.Callable[[re.Match[str]], str]]
 ) -> str:
     """
     Replace `text` with `repl` using Javascript style regular expression to find matches.
@@ -1228,7 +1228,7 @@ def reg_exp_js_replace(
 def reg_exp_replace(
     text: t.Any,
     pattern: t.Any,
-    repl: t.Union[str, t.Callable[[re.Match], str]],
+    repl: t.Union[str, t.Callable[[re.Match[str]], str]],
     ignore_case: bool = False,
     count: int = 0,
 ) -> str:
@@ -1293,7 +1293,7 @@ def repeat(text: t.Any, n: t.SupportsInt = 0) -> str:
 def replace(
     text: t.Any,
     pattern: t.Any,
-    repl: t.Union[str, t.Callable[[re.Match], str]],
+    repl: t.Union[str, t.Callable[[re.Match[str]], str]],
     ignore_case: bool = False,
     count: int = 0,
     escape: bool = True,
@@ -1373,7 +1373,7 @@ def replace(
 def replace_end(
     text: t.Any,
     pattern: t.Any,
-    repl: t.Union[str, t.Callable[[re.Match], str]],
+    repl: t.Union[str, t.Callable[[re.Match[str]], str]],
     ignore_case: bool = False,
     escape: bool = True,
 ) -> str:
@@ -1408,7 +1408,7 @@ def replace_end(
 def replace_start(
     text: t.Any,
     pattern: t.Any,
-    repl: t.Union[str, t.Callable[[re.Match], str]],
+    repl: t.Union[str, t.Callable[[re.Match[str]], str]],
     ignore_case: bool = False,
     escape: bool = True,
 ) -> str:
@@ -2021,7 +2021,7 @@ def truncate(
     text: t.Any,
     length: int = 30,
     omission: str = "...",
-    separator: t.Union[str, re.Pattern, None] = None,
+    separator: t.Union[str, re.Pattern[str], None] = None,
 ) -> str:
     """
     Truncates `text` if it is longer than the given maximum string length. The last characters of
@@ -2353,7 +2353,7 @@ def flatten_url_params(
     if isinstance(params, dict):
         params = list(params.items())
 
-    flattened: t.List = []
+    flattened: t.List[t.Any] = []
     for param, value in params:
         if isinstance(value, (list, tuple)):
             flattened += zip([param] * len(value), value)

--- a/src/pydash/utilities.py
+++ b/src/pydash/utilities.py
@@ -64,7 +64,7 @@ __all__ = (
 
 T = t.TypeVar("T")
 T2 = t.TypeVar("T2")
-CallableT = t.TypeVar("CallableT", bound=t.Callable)
+CallableT = t.TypeVar("CallableT", bound=t.Callable[..., t.Any])
 P = ParamSpec("P")
 
 # These regexes are used in to_path() to parse deep path strings.
@@ -186,7 +186,7 @@ def conforms(source: t.Dict[T, t.Callable[[T2], t.Any]]) -> t.Callable[[t.Dict[T
 def conforms(source: t.List[t.Callable[[T], t.Any]]) -> t.Callable[[t.List[T]], bool]: ...
 
 
-def conforms(source: t.Union[t.List, t.Dict]) -> t.Callable:
+def conforms(source: t.Union[t.List[t.Any], t.Dict[t.Any, t.Any]]) -> t.Callable[..., t.Any]:
     """
     Creates a function that invokes the predicate properties of `source` with the corresponding
     property values of a given object, returning ``True`` if all predicates return truthy, else
@@ -417,7 +417,7 @@ def iteratee(func: t.Callable[P, T]) -> t.Callable[P, T]: ...
 
 
 @t.overload
-def iteratee(func: t.Any) -> t.Callable: ...
+def iteratee(func: t.Any) -> t.Callable[..., t.Any]: ...
 
 
 def iteratee(func):
@@ -1229,7 +1229,7 @@ def retry(
     return decorator
 
 
-def stub_list() -> t.List:
+def stub_list() -> t.List[t.Any]:
     """
     Returns empty "list".
 
@@ -1246,7 +1246,7 @@ def stub_list() -> t.List:
     return []
 
 
-def stub_dict() -> t.Dict:
+def stub_dict() -> t.Dict[t.Any, t.Any]:
     """
     Returns empty "dict".
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,7 +1,9 @@
+import typing as t
+
 import pydash as _
 
 
-def typed_function(row: int, index: int, col: list):
+def typed_function(row: int, index: int, col: t.List[t.Any]):
     return row + 1
 
 


### PR DESCRIPTION
Following on https://github.com/dgilland/pydash/issues/228 and on a way to even better/stricter type support this enables the `disallow_any_generics` mypy rule and fixes all the issues related to this, specifying all generic type variable.