### PR TITLE
fix: support iterables in take_while and drop_while

### DIFF
--- a/src/pydash/arrays.py
+++ b/src/pydash/arrays.py
@@ -449,14 +449,15 @@ def drop_while(array, predicate=None):
 
     .. versionadded:: 1.1.0
     """
+    arr = list(array)
     n = 0
-    for is_true, _, _, _ in iteriteratee(array, predicate):
+    for is_true, _, _, _ in iteriteratee(arr, predicate):
         if is_true:
             n += 1
         else:
             break
 
-    return array[n:]
+    return arr[n:]
 
 
 def duplicates(
@@ -2093,14 +2094,15 @@ def take_while(array, predicate=None):
 
     .. versionadded:: 1.1.0
     """
+    arr = list(array)
     n = 0
-    for is_true, _, _, _ in iteriteratee(array, predicate):
+    for is_true, _, _, _ in iteriteratee(arr, predicate):
         if is_true:
             n += 1
         else:
             break
 
-    return array[:n]
+    return arr[:n]
 
 
 @t.overload

--- a/src/pydash/arrays.py
+++ b/src/pydash/arrays.py
@@ -449,15 +449,15 @@ def drop_while(array, predicate=None):
 
     .. versionadded:: 1.1.0
     """
-    arr = list(array)
-    n = 0
-    for is_true, _, _, _ in iteriteratee(arr, predicate):
-        if is_true:
-            n += 1
-        else:
-            break
+    result = []
+    dropping = True
+    for is_true, value, _, _ in iteriteratee(array, predicate):
+        if dropping and is_true:
+            continue
+        dropping = False
+        result.append(value)
 
-    return arr[n:]
+    return result
 
 
 def duplicates(
@@ -2094,15 +2094,13 @@ def take_while(array, predicate=None):
 
     .. versionadded:: 1.1.0
     """
-    arr = list(array)
-    n = 0
-    for is_true, _, _, _ in iteriteratee(arr, predicate):
-        if is_true:
-            n += 1
-        else:
+    result = []
+    for is_true, value, _, _ in iteriteratee(array, predicate):
+        if not is_true:
             break
+        result.append(value)
 
-    return arr[:n]
+    return result
 
 
 @t.overload

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -104,6 +104,7 @@ def test_drop(case, expected):
     "case,expected",
     [
         (([1, 2, 3, 4, 5], lambda item: item < 3), [3, 4, 5]),
+        ((iter([1, 2, 3, 4, 5]), lambda item: item < 3), [3, 4, 5]),
     ],
 )
 def test_drop_while(case, expected):
@@ -723,6 +724,7 @@ def test_take(case, expected):
     "case,expected",
     [
         (([1, 2, 3, 4, 5], lambda item: item < 3), [1, 2]),
+        ((iter([1, 2, 3, 4, 5]), lambda item: item < 3), [1, 2]),
     ],
 )
 def test_take_while(case, expected):


### PR DESCRIPTION
`take_while` and `drop_while` (and their callers `take`/`drop`) raise `TypeError: 'generator' object is not subscriptable` when passed a generator or other non-subscriptable iterable, because both functions slice the original `array` after counting. Converting to a list first fixes the crash on valid input.

Fixes #204.