### PR TITLE
Restrict dunder path access on objects

### DIFF
--- a/src/pydash/helpers.py
+++ b/src/pydash/helpers.py
@@ -26,8 +26,8 @@ NUMBER_TYPES = (int, float, Decimal)
 #: Dictionary of builtins with keys as the builtin function and values as the string name.
 BUILTINS = {value: key for key, value in builtins.__dict__.items() if isinstance(value, Hashable)}
 
-#: Object keys that are restricted from access via path access.
-RESTRICTED_KEYS = ("__globals__", "__builtins__")
+#: Object key marker that is restricted from access via path access.
+RESTRICTED_KEY_MARKER = "__"
 
 #: Inspect signature parameter kinds that correspond to positional arguments.
 POSITIONAL_PARAMETERS = (
@@ -218,7 +218,11 @@ def _base_get_object(obj, key, default=UNSET):
 def _raise_if_restricted_key(*keys):
     # Prevent access to restricted keys for security reasons.
     for key in keys:
-        if key in RESTRICTED_KEYS:
+        if (
+            isinstance(key, str)
+            and key.startswith(RESTRICTED_KEY_MARKER)
+            and key.endswith(RESTRICTED_KEY_MARKER)
+        ):
             raise KeyError(f"access to restricted key {key!r} is not allowed")
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -223,12 +223,16 @@ def test_invoke(case, expected):
     [
         ({}, "__globals__"),
         ({}, "__builtins__"),
+        ({}, "__class__"),
         ({}, "a.__globals__.b"),
         ({}, "a.__builtins__.b"),
+        ({}, "a.__class__.b"),
         ([], "__globals__"),
         ([], "__builtins__"),
+        ([], "__class__"),
         ([], "a.__globals__.b"),
         ([], "a.__builtins__.b"),
+        ([], "a.__class__.b"),
     ],
 )
 def test_invoke__raises_for_objects_when_path_restricted(case):
@@ -410,6 +414,10 @@ def test_get__should_not_populate_defaultdict():
         (SomeNamedTuple(1, 2), "__globals__"),
         (helpers.Object(subobj=helpers.Object()), "subobj.__builtins__"),
         (helpers.Object(subobj=helpers.Object()), "__builtins__"),
+        (helpers.Object(), "__class__"),
+        (helpers.Object(), "__name__"),
+        (helpers.Object(subobj=helpers.Object()), "subobj.__dict__"),
+        (helpers.Object(), "__len__"),
     ],
 )
 def test_get__raises_for_objects_when_path_restricted(obj, path):
@@ -422,8 +430,10 @@ def test_get__raises_for_objects_when_path_restricted(obj, path):
     [
         ({}, "__globals__"),
         ({}, "__builtins__"),
+        ({}, "__class__"),
         ([], "__globals__"),
         ([], "__builtins__"),
+        ([], "__class__"),
     ],
 )
 def test_get__does_not_raise_for_dict_or_list_when_path_restricted(obj, path):
@@ -433,9 +443,9 @@ def test_get__does_not_raise_for_dict_or_list_when_path_restricted(obj, path):
 @parametrize(
     "obj,path",
     [
-        (helpers.Object(), "__name__"),
-        (helpers.Object(), "foo.__dict__"),
-        (helpers.Object(), "__len__"),
+        (helpers.Object(), "_name"),
+        (helpers.Object(), "foo._dict"),
+        (helpers.Object(), "_len"),
     ],
 )
 def test_get__does_not_raise_for_objects_when_path_is_unrestricted(obj, path):
@@ -787,6 +797,19 @@ def test_set_on_class_works_the_same_with_string_and_list():
     a2 = A()
 
     assert _.set_(a1, "x.a.b", 1).x == _.set_(a2, ["x", "a", "b"], 1).x
+
+
+def test_set__raises_for_objects_when_path_restricted():
+    class User:
+        is_admin = False
+
+    user = User()
+
+    with pytest.raises(KeyError, match="access to restricted key"):
+        _.set_(user, "__class__.is_admin", True)
+
+    assert User.is_admin is False
+    assert User().is_admin is False
 
 
 @parametrize(


### PR DESCRIPTION
## Summary
- restore object path restrictions from a two-key denylist to any dunder key
- add `__class__` coverage for `get`/`invoke` and a `set_` regression test for class attribute pollution
- keep dict/list path access behavior unchanged for matching string keys

## Tests
- `PYTHONPATH=src python -m pytest tests/test_objects.py -k "restricted or test_set__raises" --no-cov`
- `PYTHONPATH=src python -m pytest tests/test_*.py -o addopts=""`
- `python -m ruff check src/pydash/helpers.py`
- `git diff --check`

## Notes
- `PYTHONPATH=src python -m pytest --no-cov` is not the primary local verification because the default pytest config collects `tasks.py` without the optional dev dependency `invoke`, and collects mypy-testing files without enabling their plugin mode.

Closes #240