### PR TITLE
Support flattening nested iterables

### DIFF
--- a/src/pydash/arrays.py
+++ b/src/pydash/arrays.py
@@ -7,6 +7,7 @@ Functions that operate on lists.
 from __future__ import annotations
 
 from bisect import bisect_left, bisect_right
+from collections.abc import Iterable, Mapping
 from functools import cmp_to_key
 from math import ceil
 import typing as t
@@ -2818,11 +2819,15 @@ def zip_with(*arrays, **kwargs):
 def iterflatten(array, depth=-1):
     """Iteratively flatten a list shallowly or deeply."""
     for item in array:
-        if isinstance(item, (list, tuple)) and depth != 0:
+        if is_flattenable(item) and depth != 0:
             for subitem in iterflatten(item, depth - 1):
                 yield subitem
         else:
             yield item
+
+
+def is_flattenable(value):
+    return isinstance(value, Iterable) and not isinstance(value, (str, bytes, bytearray, Mapping))
 
 
 def iterinterleave(*arrays):

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -206,6 +206,8 @@ def test_find_last_index(case, filter_by, expected):
     "case,expected",
     [
         ([1, ["2222"], [3, [[4]]]], [1, "2222", 3, [[4]]]),
+        ([iter([1, 2]), iter([3, [[4]]])], [1, 2, 3, [[4]]]),
+        ([{"a": 1}, [2]], [{"a": 1}, 2]),
     ],
 )
 def test_flatten(case, expected):
@@ -216,6 +218,8 @@ def test_flatten(case, expected):
     "case,expected",
     [
         ([1, ["2222"], [3, [[4]]]], [1, "2222", 3, 4]),
+        ([iter([1, [2]]), iter([[3, [4]]])], [1, 2, 3, 4]),
+        ([{"a": 1}, [2]], [{"a": 1}, 2]),
     ],
 )
 def test_flatten_deep(case, expected):
@@ -229,6 +233,8 @@ def test_flatten_deep(case, expected):
         (([1, ["2222"], [3, [[4]]]], 1), [1, "2222", 3, [[4]]]),
         (([1, ["2222"], [3, [[4]]]], 2), [1, "2222", 3, [4]]),
         (([1, ["2222"], [3, [[4]]]], 3), [1, "2222", 3, 4]),
+        (([iter([1, [2]])], 1), [1, [2]]),
+        (([iter([1, [2]])], 2), [1, 2]),
     ],
 )
 def test_flatten_depth(case, expected):


### PR DESCRIPTION
## Summary
- let `flatten`, `flatten_deep`, and `flatten_depth` expand nested non-string iterables such as generators/querysets
- keep strings, bytes, bytearray, and mappings as atomic values while flattening
- add generator coverage for shallow/deep/depth flattening and preserve dict behavior

## Tests
- `PYTHONPATH=src python -m pytest tests/test_arrays.py -k "flatten" --no-cov`
- `PYTHONPATH=src python -m pytest tests/test_arrays.py --no-cov`
- `PYTHONPATH=src python -m pytest tests/test_*.py -o addopts=""`
- `python -m ruff check src/pydash/arrays.py tests/test_arrays.py --extend-ignore PLW0108`
- `python -m ruff format --check src/pydash/arrays.py tests/test_arrays.py`
- `git diff --check`

## Notes
- The local default pytest command is not the primary verification here because this environment lacks the optional dev/mypy-test setup used by the project config.

Closes #171