### PR TITLE
fix: prevent StopIteration leak in iterintersperse on empty iterable

### DIFF
--- a/src/pydash/arrays.py
+++ b/src/pydash/arrays.py
@@ -2844,7 +2844,11 @@ def iterinterleave(*arrays):
 def iterintersperse(iterable, separator):
     """Iteratively intersperse iterable."""
     iterable = iter(iterable)
-    yield next(iterable)
+    try:
+        item = next(iterable)
+    except StopIteration:
+        return
+    yield item
     for item in iterable:
         yield separator
         yield item

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -350,6 +350,7 @@ def test_intersection_with(case, expected):
 @parametrize(
     "case,expected",
     [
+        (([], "x"), []),
         (([1, 2, 3, 4], 10), [1, 10, 2, 10, 3, 10, 4]),
         (([1, 2, 3, 4], [0, 0, 0]), [1, [0, 0, 0], 2, [0, 0, 0], 3, [0, 0, 0], 4]),
         (


### PR DESCRIPTION
## Problem

`intersperse([], "x")` raises `RuntimeError: generator raised StopIteration` instead of returning `[]`.

`iterintersperse()` calls `next()` directly on a fresh iterator without guarding against empty input. In Python 3.7+ (PEP 479), bare `StopIteration` raised inside a generator is automatically converted to `RuntimeError`.

## Fix

Catch `StopIteration` and return early from the generator, so that `intersperse([], "x")` returns `[]`.

## Test

Added a test case for empty-list input to `test_intersperse`.

## Before/After

```python
# Before (Python 3.11)
>>> intersperse([], "x")
RuntimeError: generator raised StopIteration

# After
>>> intersperse([], "x")
[]
```