### PR TITLE
fix: floor/ceil/round_ used as iteratees silently pass index as precision

### DIFF
--- a/src/pydash/numerical.py
+++ b/src/pydash/numerical.py
@@ -320,6 +320,11 @@ def ceil(x: NumberT, precision: int = 0) -> float:
     return rounder(math.ceil, x, precision)
 
 
+# When used as an iteratee (e.g. count_by, group_by), only the element value
+# should be passed; the optional `precision` parameter must not receive the
+# collection index.  Marking _argcount=1 tells callit() to pass a single arg.
+ceil._argcount = 1  # type: ignore[attr-defined]
+
 NumT = t.TypeVar("NumT", int, float, "Decimal")
 NumT2 = t.TypeVar("NumT2", int, float, "Decimal")
 NumT3 = t.TypeVar("NumT3", int, float, "Decimal")
@@ -412,6 +417,12 @@ def floor(x: NumberT, precision: int = 0) -> float:
     .. versionadded:: 3.3.0
     """
     return rounder(math.floor, x, precision)
+
+
+# When used as an iteratee (e.g. count_by, group_by), only the element value
+# should be passed; the optional `precision` parameter must not receive the
+# collection index.  Marking _argcount=1 tells callit() to pass a single arg.
+floor._argcount = 1  # type: ignore[attr-defined]
 
 
 @t.overload
@@ -941,6 +952,12 @@ def round_(x, precision=0):
         Remove alias ``curve``.
     """
     return rounder(round, x, precision)
+
+
+# When used as an iteratee (e.g. count_by, group_by), only the element value
+# should be passed; the optional `precision` parameter must not receive the
+# collection index.  Marking _argcount=1 tells callit() to pass a single arg.
+round_._argcount = 1  # type: ignore[attr-defined]
 
 
 @t.overload

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -31,6 +31,11 @@ def test_at(case, expected):
         (([{"one": 1}, {"one": 1}, {"two": 2}, {"one": 1}], {"one": 1}), {True: 3, False: 1}),
         (([{"one": 1}, {"one": 1}, {"two": 2}, {"one": 1}], "one"), {1: 3, None: 1}),
         (({1: 0, 2: 0, 4: 3},), {0: 2, 3: 1}),
+        # pydash.floor/ceil/round_ have an optional `precision` arg; when used as
+        # an iteratee the collection index must not be passed as precision.
+        (([6.1, 4.2, 6.3], _.floor), {6.0: 2, 4.0: 1}),
+        (([6.1, 4.2, 6.3], _.ceil), {7.0: 2, 5.0: 1}),
+        (([1.1, 1.9, 2.1], _.round_), {1.0: 1, 2.0: 2}),
     ],
 )
 def test_count_by(case, expected):


### PR DESCRIPTION
## Bug

`pydash.floor`, `pydash.ceil`, and `pydash.round_` each accept an optional
`precision` argument.  `helpers.getargcount()` counts all positional
parameters and therefore returns `2` for these functions.  When `callit()`
invokes them inside `iteriteratee()` it passes `(element, index, collection)`
truncated to `argcount=2`, so the collection index is forwarded as `precision`.
This produces silently wrong results whenever these functions are used directly
as iteratees.

### Reproducer

```python
import pydash as _

# Reported expected: {6.0: 2, 4.0: 1}
_.count_by([6.1, 4.2, 6.3], _.floor)
# Actual:   {6.0: 1, 4.2: 1, 6.3: 1}
#
# floor(6.1, 0) == 6.0  ✓  (index 0 → precision 0, happens to be correct)
# floor(4.2, 1) == 4.2  ✗  (index 1 → precision 1, rounds to 1 decimal)
# floor(6.3, 2) == 6.3  ✗  (index 2 → precision 2, rounds to 2 decimals)
```

The same bug affects `_.ceil` and `_.round_`.  Equivalent lambdas work fine
because `lambda x: _.floor(x)` only has one positional parameter.

## Fix

Set `_argcount = 1` on `floor`, `ceil`, and `round_` after their definitions.
This is the existing optimization mechanism already used by iteratees returned
from `utilities.iteratee()` and the wrappers in `functions.py`; it tells
`callit()` to supply only the element value.

Normal two-argument use (`floor(3.75, 1)`) is completely unaffected.

## Tests

Three new parametrize cases added to `test_count_by` — one per affected
function — covering the previously broken behavior.