### PR TITLE
Fix to_list() returning dict_values instead of a list for dicts (#249)

### DIFF
--- a/src/pydash/objects.py
+++ b/src/pydash/objects.py
@@ -2115,7 +2115,7 @@ def to_list(obj, split_strings=True):
     if isinstance(obj, list):
         return obj[:]
     elif isinstance(obj, dict):
-        return obj.values()
+        return list(obj.values())
     elif not split_strings and isinstance(obj, (str, bytes)):
         return [obj]
     elif split_strings and isinstance(obj, bytes):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -181,6 +181,21 @@ def test_to_dict(case, expected):
 @parametrize(
     "case,expected",
     [
+        ({"a": 1, "b": 2, "c": 3}, [1, 2, 3]),
+        ([1, 2, 3], [1, 2, 3]),
+        ((1, 2), [1, 2]),
+        (1, [1]),
+    ],
+)
+def test_to_list(case, expected):
+    result = _.to_list(case)
+    assert result == expected
+    assert isinstance(result, list)
+
+
+@parametrize(
+    "case,expected",
+    [
         ({"a": 1, "b": 2, "c": 3}, {1: "a", 2: "b", 3: "c"}),
         ([1, 2, 3], {1: 0, 2: 1, 3: 2}),
     ],


### PR DESCRIPTION
Fixes #249.

## Problem

`to_list()` returns a `dict_values` view rather than a `list` when given a dict:

```python
>>> import pydash as _
>>> _.to_list({"a": 1, "b": 2})
dict_values([1, 2])          # not a list
>>> isinstance(_.to_list({"a": 1, "b": 2}), list)
False
```

Every other branch of `to_list` returns a real `list`, the docstring says "Converts ... to a list", and the typed signature (and the mypy `reveal_type` tests for `to_list`) promise `list[T]`. Only the dict branch (`return obj.values()`) breaks the contract.

## Fix

`return list(obj.values())`.

## Test

Added `test_to_list` in `tests/test_objects.py` covering dict, list, tuple, and scalar inputs, asserting both the value and `isinstance(result, list)`. Verified the dict case fails on the current code (`assert dict_values([1, 2, 3]) == [1, 2, 3]`) and passes with the fix.

Local verification on 2026-07-02 with Python 3.12.10:

```console
$env:PYTHONPATH='src'; python -m pytest tests/test_objects.py --no-cov
290 passed
```

Happy to add a CHANGELOG entry if you'd like; I left it out since the changelog looks maintainer-managed per release.
