### PR TITLE
fix: return NaN from mean/mean_by on empty collections

### DIFF
--- a/src/pydash/numerical.py
+++ b/src/pydash/numerical.py
@@ -289,10 +289,15 @@ def mean_by(collection, iteratee=None):
 
         >>> mean_by([1, 2, 3, 4], lambda x: x**2)
         7.5
+        >>> math.isnan(mean_by([]))
+        True
 
     .. versionadded:: 4.0.0
     """
-    return sum_by(collection, iteratee) / len(collection)
+    length = len(collection)
+    if not length:
+        return float("nan")
+    return sum_by(collection, iteratee) / length
 
 
 def ceil(x: NumberT, precision: int = 0) -> float:

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 import pydash as _
@@ -118,6 +120,11 @@ def test_mean(case, expected):
     assert _.mean(case) == expected
 
 
+def test_mean_empty():
+    assert math.isnan(_.mean([]))
+    assert math.isnan(_.mean({}))
+
+
 @parametrize(
     "case,expected",
     [
@@ -129,6 +136,11 @@ def test_mean(case, expected):
 )
 def test_mean_by(case, expected):
     assert _.mean_by(*case) == expected
+
+
+def test_mean_by_empty():
+    assert math.isnan(_.mean_by([]))
+    assert math.isnan(_.mean_by([], lambda x: x * 2))
 
 
 @parametrize(


### PR DESCRIPTION
mean hits ZeroDivisionError when mean([]). This PR fixes the regression with a focused test covering the case.
