### PR TITLE
fix: return NaN from median on empty collections

### DIFF
--- a/src/pydash/numerical.py
+++ b/src/pydash/numerical.py
@@ -631,6 +631,9 @@ def median(collection, iteratee=None):
     .. versionadded:: 2.1.0
     """
     length = len(collection)
+    if not length:
+        # Match mean_by: empty collection has no median.
+        return float("nan")
     middle = (length + 1) / 2
     collection = sorted(ret[0] for ret in iteriteratee(collection, iteratee))
 

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 import pydash as _
@@ -142,6 +144,11 @@ def test_mean_by(case, expected):
 )
 def test_median(case, expected):
     assert _.median(*case) == expected
+
+
+def test_median_empty():
+    assert math.isnan(_.median([]))
+    assert math.isnan(_.median({}))
 
 
 @parametrize(


### PR DESCRIPTION
pydash.numerical.median hits IndexError when median([]). This PR fixes the regression with a focused test covering the case.
