### PR TITLE
Fix last_index_of missing a match at index 0

### DIFF
--- a/src/pydash/arrays.py
+++ b/src/pydash/arrays.py
@@ -1083,7 +1083,7 @@ def last_index_of(
         # Set starting index base on from_index offset.
         index = max(0, index + from_index) if from_index < 0 else min(from_index, index - 1)
 
-    while index:
+    while index >= 0:
         if index < array_len and array[index] == value:
             return index
         index -= 1

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -398,6 +398,9 @@ def test_last(case, expected):
         ([0, 1, 2, 3, 4, 5], 3, -5, -1),
         ([0, 1, 2, 3, 4, 5], 3, -6, -1),
         ([0, 1, 2, 3, 4, 5], 3, None, 3),
+        ([1, 2, 3], 1, None, 0),
+        ([1, 2, 3], 1, 0, 0),
+        ([5, 2, 3], 5, None, 0),
     ],
 )
 def test_last_index_of(case, value, from_index, expected):


### PR DESCRIPTION
`last_index_of` walks `index` down from the end of the array, but the loop guard is `while index:`. That exits as soon as `index` reaches `0`, so **element 0 is never compared** — and the function returns `-1` whenever the value's last occurrence is at index 0.

```python
>>> from pydash import last_index_of
>>> last_index_of([1, 2, 3], 1)
-1          # expected 0
>>> last_index_of([5, 2, 3], 5, from_index=0)
-1          # expected 0
```

This contradicts the documented contract ("Index of found item or `-1` if not found") and diverges from the sibling `index_of`, which delegates to `list.index` and finds index 0 correctly (`index_of([1, 2, 3], 1) == 0`).

Fix: use `while index >= 0:` so index 0 is compared. The existing `if index < array_len` guard already prevents any out-of-range access, and an empty array still returns `-1` (the `0 < 0` guard is False). Added regression tests for a match at index 0.
