### PR TITLE
Fix median for iterators and generators

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,3 +33,5 @@ Contributors
 - santhreal, `santhreal@github <https://github.com/santhreal>`_
 - gaoflow, `gaoflow@github <https://github.com/gaoflow>`_
 - HarperZ9, `HarperZ9@github <https://github.com/HarperZ9>`_
+
+- oyeong011

--- a/src/pydash/numerical.py
+++ b/src/pydash/numerical.py
@@ -635,12 +635,12 @@ def median(collection, iteratee=None):
 
     .. versionadded:: 2.1.0
     """
+    collection = sorted(ret[0] for ret in iteriteratee(collection, iteratee))
     length = len(collection)
     if not length:
         # Match mean_by: empty collection has no median.
         return float("nan")
     middle = (length + 1) / 2
-    collection = sorted(ret[0] for ret in iteriteratee(collection, iteratee))
 
     if pyd.is_odd(length):
         result = collection[int(middle - 1)]

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -156,6 +156,20 @@ def test_median(case, expected):
     assert _.median(*case) == expected
 
 
+@parametrize("values,expected", [([3, 1, 2], 2), ([4, 1, 3, 2], 2.5)])
+def test_median_iterator(values, expected):
+    assert _.median(iter(values)) == expected
+
+
+def test_median_iterator_with_iteratee():
+    values = ({"value": value} for value in [3, 1, 2])
+    assert _.median(values, "value") == 2
+
+
+def test_median_empty_iterator():
+    assert math.isnan(_.median(iter([])))
+
+
 def test_median_empty():
     assert math.isnan(_.median([]))
     assert math.isnan(_.median({}))


### PR DESCRIPTION
Fix median for iterators and generators.

median() advertises Iterable inputs but calls len() before consuming them, so iterators and generators raise TypeError. Calculate length after the existing sorted materialization; cover odd/even inputs, iteratees and empty iterators.

Validation: upstream `inv ci` passes on Python 3.14: build, docs, Ruff, mypy, generated chain types, and 2278 tests/doctests with 100% coverage. Public API and chain QA also pass. Other Python versions were not run.

AI assistance: This change and its regression tests were prepared with OpenAI Codex.
