### PR TITLE
Fix throttle dropping trailing calls during the wait period

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,3 +33,4 @@ Contributors
 - santhreal, `santhreal@github <https://github.com/santhreal>`_
 - gaoflow, `gaoflow@github <https://github.com/gaoflow>`_
 - HarperZ9, `HarperZ9@github <https://github.com/HarperZ9>`_
+- jackwalkerlabs, `jackwalkerlabs@github <https://github.com/jackwalkerlabs>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Fix ``throttle`` dropping calls during the wait period: invoke once on the trailing edge with
+  the latest arguments. Trailing invocations run in a daemon timer thread.
+
 v8.1.0 (2026-08-29)
 -------------------
 

--- a/src/pydash/functions.py
+++ b/src/pydash/functions.py
@@ -658,20 +658,56 @@ class Throttle(_WithArgCount, t.Generic[P, T]):
         self.last_result: t.Union[T, None] = None
         self.last_execution = pyd.now() - self.wait
 
+        self._lock = threading.RLock()
+        self._timer: t.Optional[threading.Timer] = None
+        self._args: t.Tuple[t.Any, ...] = ()
+        self._kwargs: t.Dict[str, t.Any] = {}
+        self._generation = 0
+
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
         """
-        Execute :attr:`func` if function hasn't been called within last :attr:`wait` milliseconds.
+        Execute immediately if the wait has elapsed, otherwise schedule the latest call for the
+        end of the current wait period.
 
         Return results of last successful call.
         """
-        present = pyd.now()
+        with self._lock:
+            self._args = args
+            self._kwargs = kwargs
+            present = pyd.now()
+            remaining = self.wait - (present - self.last_execution)
 
-        if (present - self.last_execution) >= self.wait:
-            self.last_result = self.func(*args, **kwargs)
-            self.last_execution = present
+            if remaining <= 0:
+                if self._timer is not None:
+                    self._timer.cancel()
+                self._generation += 1
+                return self._invoke(present)
 
-        # The last result will be filled on first execution, so it is always `T`
-        return self.last_result  # type: ignore
+            if self._timer is None:
+                self._generation += 1
+                self._timer = threading.Timer(
+                    remaining / 1000.0, self._on_timer, (self._generation,)
+                )
+                self._timer.daemon = True
+                self._timer.start()
+
+            # The first call executes immediately and fills last_result.
+            return self.last_result  # type: ignore
+
+    def _on_timer(self, generation: int) -> None:
+        with self._lock:
+            if generation != self._generation:
+                return
+            self._invoke(pyd.now())
+
+    def _invoke(self, present: int) -> T:
+        """Execute the latest call. Caller must hold ``_lock``."""
+        args, kwargs = self._args, self._kwargs
+        self._args, self._kwargs = (), {}
+        self._timer = None
+        self.last_execution = present
+        self.last_result = self.func(*args, **kwargs)
+        return self.last_result
 
 
 def after(func: t.Callable[P, T], n: t.SupportsInt) -> After[P, T]:
@@ -1439,6 +1475,10 @@ def throttle(func: t.Callable[P, T], wait: int) -> Throttle[P, T]:
     Creates a function that, when executed, will only call the `func` function at most once per
     every `wait` milliseconds. Subsequent calls to the throttled function will return the result of
     the last `func` call.
+
+    The first call executes immediately. If called again during the wait period, `func` also runs
+    once at the end of that period with the latest arguments. This trailing call runs in a daemon
+    timer thread. A single call does not schedule a second invocation.
 
     Args:
         func: Function to throttle.

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,3 +1,5 @@
+import heapq
+import threading
 import time
 from unittest import mock
 
@@ -374,6 +376,129 @@ def test_throttle():
 
     time.sleep(100 / 1000.0)
     assert throttled() > expected
+
+
+def test_throttle_trailing_call():
+    calls = []
+    finished = threading.Event()
+
+    def func(value, *, suffix):
+        calls.append((value, suffix))
+        if value == "last":
+            finished.set()
+        return value
+
+    throttled = _.throttle(func, 100)
+    assert throttled("first", suffix="a") == "first"
+    assert throttled("middle", suffix="b") == "first"
+    assert throttled("last", suffix="c") == "first"
+    assert finished.wait(1), "the last call in the burst was dropped"
+    assert calls == [("first", "a"), ("last", "c")]
+
+
+@pytest.fixture
+def throttle_clock(monkeypatch):
+    now = [1000]
+    queue = []
+    timers = []
+
+    class Timer:
+        def __init__(self, interval, function, args):
+            self.when = now[0] + interval * 1000
+            self.function = function
+            self.args = args
+            self.cancelled = False
+            timers.append(self)
+
+        def start(self):
+            heapq.heappush(queue, (self.when, len(timers), self))
+
+        def cancel(self):
+            self.cancelled = True
+
+    def advance(milliseconds, run_timers=True):
+        target = now[0] + milliseconds
+        while run_timers and queue and queue[0][0] <= target:
+            when, _, timer = heapq.heappop(queue)
+            now[0] = max(now[0], when)
+            if not timer.cancelled:
+                timer.function(*timer.args)
+        now[0] = target
+
+    monkeypatch.setattr(_, "now", lambda: now[0])
+    monkeypatch.setattr(threading, "Timer", Timer)
+    return advance, timers
+
+
+def test_throttle_single_call_does_not_repeat(throttle_clock):
+    advance, timers = throttle_clock
+    func = mock.Mock(return_value="result")
+    throttled = _.throttle(func, 100)
+    assert throttled("first") == "result"
+    advance(200)
+    func.assert_called_once_with("first")
+    assert timers == []
+
+
+def test_throttle_keeps_fixed_trailing_deadline(throttle_clock):
+    advance, _timers = throttle_clock
+    calls = []
+
+    def func(value):
+        calls.append((_.now(), value))
+        return value
+
+    throttled = _.throttle(func, 100)
+    assert throttled(1) == 1
+    advance(20)
+    assert throttled(2) == 1
+    advance(40)
+    assert throttled(3) == 1
+    advance(40)
+    assert calls == [(1000, 1), (1100, 3)]
+    assert throttled.last_result == 3
+    advance(50)
+    assert throttled(4) == 3
+    advance(50)
+    assert calls == [(1000, 1), (1100, 3), (1200, 4)]
+    advance(200)
+    assert throttled(5) == 5
+
+
+def test_throttle_late_timer_does_not_duplicate_new_call(throttle_clock):
+    advance, timers = throttle_clock
+    func = mock.Mock(side_effect=lambda value: value)
+    throttled = _.throttle(func, 100)
+    assert throttled("first") == "first"
+    advance(20)
+    throttled("old")
+    old_timer = timers[0]
+
+    # Simulate a busy timer thread: a new call arrives after the deadline first.
+    advance(100, run_timers=False)
+    assert throttled("new") == "new"
+    assert old_timer.cancelled
+    throttled("pending")
+    # Timer.cancel cannot stop a callback that has already started.
+    old_timer.function(*old_timer.args)
+    advance(100)
+    assert func.call_args_list == [mock.call("first"), mock.call("new"), mock.call("pending")]
+
+
+def test_throttle_reentrant_call_is_deferred(throttle_clock):
+    advance, _timers = throttle_clock
+    calls = []
+
+    def func(value):
+        calls.append(value)
+        if value == "first":
+            throttled("nested")
+        return value
+
+    throttled = _.throttle(func, 100)
+    assert throttled("first") == "first"
+    advance(100)
+    assert calls == ["first", "nested"]
 
 
 @parametrize(


### PR DESCRIPTION
Fixes #115.

`throttle` currently drops every call made during the wait period. Keep the leading call immediate and schedule one trailing call with the latest positional and keyword arguments. Further calls update those arguments without moving the deadline. A single call still runs only once, and suppressed calls return the last successful result.

Use a reentrant lock to serialize calls and timer callbacks, and invalidate a late timer when a newer immediate call has superseded it. Trailing invocations run in a daemon thread, as documented in the docstring and changelog.

Added five tests covering the reported real-timer failure, single-call behavior, fixed deadlines and subsequent bursts, late-timer cancellation, and reentrant calls. The reported trailing-call regression fails on the original code.

Validation: the full supported-version tox matrix passes on Python 3.10, 3.11, 3.12, 3.13, and 3.14. Each environment runs package/docs builds, Ruff, mypy, generated-chain checks, and 2,279 tests/doctests with 100% coverage.

Implemented and locally validated with OpenAI Codex.
