### PR TITLE
Fix scale returning empty results for iterators

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,3 +33,4 @@ Contributors
 - santhreal, `santhreal@github <https://github.com/santhreal>`_
 - gaoflow, `gaoflow@github <https://github.com/gaoflow>`_
 - HarperZ9, `HarperZ9@github <https://github.com/HarperZ9>`_
+- Gonghan-Princess, `Gonghan-Princess@github <https://github.com/Gonghan-Princess>`_

--- a/src/pydash/numerical.py
+++ b/src/pydash/numerical.py
@@ -1004,6 +1004,7 @@ def scale(array, maximum: NumberT = 1):
 
     .. versionadded:: 2.1.0
     """
+    array = list(array)
     array_max = max(array)
     factor = maximum / array_max
     return [item * factor for item in array]

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import math
 
 import pytest
@@ -269,6 +270,27 @@ def test_round_(case, expected):
 )
 def test_scale(case, expected):
     assert _.scale(*case) == expected
+
+
+@parametrize("iterable", [iter, lambda values: (value for value in values)])
+@parametrize(
+    "values,maximum,expected",
+    [
+        ([2, 5, 10], 1, [0.2, 0.5, 1]),
+        ([2, 5, 10], 10, [2, 5, 10]),
+        ([-2, 0, 4], 2, [-1, 0, 2]),
+        ([5], 1, [1]),
+        ([Decimal("1"), Decimal("2")], Decimal("1"), [Decimal("0.5"), Decimal("1")]),
+    ],
+)
+def test_scale_iterable(iterable, values, maximum, expected):
+    assert _.scale(iterable(values), maximum) == expected
+
+
+@parametrize("values,error", [([], ValueError), ([0, 0], ZeroDivisionError)])
+def test_scale_iterable_errors(values, error):
+    with pytest.raises(error):
+        _.scale(iter(values))
 
 
 @parametrize(


### PR DESCRIPTION
`scale()` accepts an `Iterable`, but `max(array)` consumes an iterator before the output comprehension reads it. For example, `scale(iter([2, 5, 10]))` currently returns `[]` instead of `[0.2, 0.5, 1.0]`.

Materialize the input before finding its maximum so both passes use the same values. This preserves order and numeric types, at the cost of O(n) additional references. Add iterator/generator regressions covering custom maxima, mixed signs, singleton inputs and Decimal values, plus controls for the existing empty-input and zero-maximum errors. Add the contributor entry requested by CONTRIBUTING.rst.

Validation on Windows:

- The 10 new result cases fail on the base revision and pass with this change; both error controls pass before and after.
- Python 3.11.15, 3.12.10, 3.13.14 and 3.14.7: all 2,286 tests/doctests pass, with 100% coverage.
- Python 3.10.20: 2,285 pass; `test_debounce` fails at the timing assertion after a 10 ms sleep. The identical failure reproduces on an unmodified checkout of the base revision. No debounce code is changed.
- Ruff lint/format, mypy, generated chaining stub comparison, Sphinx with `-W`, wheel/sdist builds and `twine check` pass under Python 3.12. Component commands were used for the POSIX-oriented Invoke tasks; the full tox matrix was not run.

Codex helped investigate, implement and test this contribution under the submitting account's authorization.
