### PR TITLE
Fix mean and variance for iterators and generators

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,3 +33,4 @@ Contributors
 - santhreal, `santhreal@github <https://github.com/santhreal>`_
 - gaoflow, `gaoflow@github <https://github.com/gaoflow>`_
 - HarperZ9, `HarperZ9@github <https://github.com/HarperZ9>`_
+- Sun Haoyuan, `Shy7777@github <https://github.com/Shy7777>`_

--- a/src/pydash/numerical.py
+++ b/src/pydash/numerical.py
@@ -1162,6 +1162,8 @@ def variance(array):
 
     .. versionadded:: 2.1.0
     """
+    if not isinstance(array, Sized):
+        array = list(array)
     avg = mean(array)
 
     def var(x):

--- a/src/pydash/numerical.py
+++ b/src/pydash/numerical.py
@@ -6,6 +6,7 @@ Numerical/mathematical related functions.
 
 from __future__ import annotations
 
+from collections.abc import Sized
 import math
 import operator
 import typing as t
@@ -294,6 +295,8 @@ def mean_by(collection, iteratee=None):
 
     .. versionadded:: 4.0.0
     """
+    if not isinstance(collection, Sized):
+        collection = list(collection)
     length = len(collection)
     if not length:
         return float("nan")

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -114,6 +114,8 @@ def test_max_default(collection, default, expected):
     [
         ([1, 2, 3, 4, 5], 3),
         ([0, 0.5, 1], 0.5),
+        (iter([1, 2, 3, 4, 5]), 3),
+        ((value for value in [0, 0.5, 1]), 0.5),
     ],
 )
 def test_mean(case, expected):
@@ -130,6 +132,7 @@ def test_mean_empty():
     [
         (([1, 2, 3, 4, 5],), 3),
         (([{"b": 4}, {"b": 5}, {"b": 6}], "b"), 5),
+        ((({"b": value} for value in [4, 5, 6]), "b"), 5),
         (([0, 0.5, 1],), 0.5),
         (({"one": {"a": 1}, "two": {"a": 2}, "three": {"a": 3}}, "a"), 2),
     ],
@@ -141,6 +144,11 @@ def test_mean_by(case, expected):
 def test_mean_by_empty():
     assert math.isnan(_.mean_by([]))
     assert math.isnan(_.mean_by([], lambda x: x * 2))
+
+
+def test_mean_empty_iterators():
+    assert math.isnan(_.mean(iter([])))
+    assert math.isnan(_.mean_by((value for value in []), "b"))
 
 
 @parametrize(

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -296,6 +296,7 @@ def test_slope(case, expected):
     "case,expected",
     [
         ([1, 2, 3], (2.0 / 3.0) ** 0.5),
+        ((value for value in [1, 2, 3]), (2.0 / 3.0) ** 0.5),
     ],
 )
 def test_std_deviation(case, expected):
@@ -369,10 +370,17 @@ def test_transpose(case, expected):
     "case,expected",
     [
         ([1, 2, 3], 2.0 / 3.0),
+        (iter([1, 2, 3]), 2.0 / 3.0),
+        ((value for value in [1, 2, 3]), 2.0 / 3.0),
     ],
 )
 def test_variance(case, expected):
     assert _.variance(case) == expected
+
+
+def test_variance_empty_iterators():
+    assert math.isnan(_.variance(iter([])))
+    assert math.isnan(_.variance(value for value in []))
 
 
 @parametrize(


### PR DESCRIPTION
`mean()` and `mean_by()` are typed to accept iterables, but currently raise `TypeError` for inputs without a length. For example, `mean(iter([1, 2, 3]))` fails instead of returning `2.0`.

Materialize unsized inputs before calculating their mean. `variance()` also saves its input before calling `mean()`, so the mean and squared-deviation passes use the same values. This also lets `std_deviation()` process those inputs through `variance()`.

Lists and dictionaries keep their current path, and empty iterators return NaN, consistent with empty collections. Unsized inputs require O(n) additional references. Regression tests cover iterators, generators, key iteratees, variance, standard deviation, and empty inputs. The contributor entry follows CONTRIBUTING.rst.

Validation on macOS with Python 3.12.13:

- 2,282 tests and doctests pass with 100% coverage under the project configuration.
- Ruff lint/format, mypy, generated chaining types, Sphinx (`-W`), and wheel/sdist builds pass.

Other supported Python versions have not been run locally.
