### PR TITLE
Fix truncate when the limit is shorter than the omission

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,3 +33,4 @@ Contributors
 - santhreal, `santhreal@github <https://github.com/santhreal>`_
 - gaoflow, `gaoflow@github <https://github.com/gaoflow>`_
 - HarperZ9, `HarperZ9@github <https://github.com/HarperZ9>`_
+- Vitaliy, `vitalivo@github <https://github.com/vitalivo>`_

--- a/src/pydash/strings.py
+++ b/src/pydash/strings.py
@@ -2046,6 +2046,8 @@ def truncate(
         'hello w...'
         >>> truncate("hello world", 10, separator=" ")
         'hello...'
+        >>> truncate("hello world", 2)
+        '...'
 
     .. versionadded:: 1.1.0
 
@@ -2058,7 +2060,7 @@ def truncate(
         return text
 
     omission_len = len(omission)
-    text_len = length - omission_len
+    text_len = max(0, length - omission_len)
     text = text[:text_len]
 
     trunc_len = len(text)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -1092,6 +1092,12 @@ def test_truncate(case, expected):
     assert _.truncate(*case) == expected
 
 
+@parametrize("length", [-1, 0, 1, 2, 3])
+@parametrize("separator", [None, " ", re.compile(" ")])
+def test_truncate_limit_no_longer_than_omission(length, separator):
+    assert _.truncate("abcdefgh", length, separator=separator) == "..."
+
+
 @parametrize(
     "case,expected",
     [


### PR DESCRIPTION
When `length` is shorter than the omission marker, `truncate()` uses a negative slice endpoint and keeps most of the input. For example, `truncate("abcdefgh", 2)` currently returns `"abcdefg..."`.

Clamp the available text length to zero so these limits return only the omission marker. Add a doctest and regression cases covering negative, zero, and small limits with no separator, a string separator, and a regex separator.

Validation: the regression cases fail in 12 combinations before the fix. `inv ci` passes on Python 3.10–3.14 (2,289 tests on each version, 100% coverage), including lint, typing, package, and documentation checks.
